### PR TITLE
feat: VRC-AI-Bot由来のPlaceType/ActorRole型を導入

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -272,6 +272,9 @@ describe('DiscordChannel', () => {
           sender_name: 'Alice',
           content: 'Hello everyone',
           is_from_me: false,
+          placeType: 'private_thread',
+          actorRole: 'owner',
+          isThread: false,
         }),
       );
     });

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -272,9 +272,9 @@ describe('DiscordChannel', () => {
           sender_name: 'Alice',
           content: 'Hello everyone',
           is_from_me: false,
-          placeType: 'private_thread',
-          actorRole: 'owner',
-          isThread: false,
+          place_type: 'guild_text',
+          actor_role: 'owner',
+          is_thread: false,
         }),
       );
     });

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -12,6 +12,7 @@ import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
   Channel,
+  InboundMessage,
   OnChatMetadata,
   OnInboundMessage,
   RegisteredGroup,
@@ -151,8 +152,10 @@ export class DiscordChannel implements Channel {
         return;
       }
 
-      // Deliver message — startMessageLoop() will pick it up
-      this.opts.onMessage(chatJid, {
+      // Deliver message — startMessageLoop() will pick it up.
+      // InboundMessage extends NewMessage with Discord-specific metadata
+      // (place_type, actor_role, is_thread) that is callback-only and not persisted.
+      const inbound: InboundMessage = {
         id: msgId,
         chat_jid: chatJid,
         sender,
@@ -163,7 +166,8 @@ export class DiscordChannel implements Channel {
         place_type: 'guild_text',
         actor_role: 'owner',
         is_thread: false,
-      });
+      };
+      this.opts.onMessage(chatJid, inbound);
 
       logger.info(
         { chatJid, chatName, sender: senderName },

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -15,6 +15,8 @@ import {
   OnChatMetadata,
   OnInboundMessage,
   RegisteredGroup,
+  type PlaceType,
+  type ActorRole,
 } from '../types.js';
 
 export interface DiscordChannelOpts {
@@ -160,6 +162,9 @@ export class DiscordChannel implements Channel {
         content,
         timestamp,
         is_from_me: false,
+        placeType: 'private_thread' as PlaceType,
+        actorRole: 'owner' as ActorRole,
+        isThread: false,
       });
 
       logger.info(

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -15,8 +15,6 @@ import {
   OnChatMetadata,
   OnInboundMessage,
   RegisteredGroup,
-  type PlaceType,
-  type ActorRole,
 } from '../types.js';
 
 export interface DiscordChannelOpts {
@@ -162,9 +160,9 @@ export class DiscordChannel implements Channel {
         content,
         timestamp,
         is_from_me: false,
-        placeType: 'private_thread' as PlaceType,
-        actorRole: 'owner' as ActorRole,
-        isThread: false,
+        place_type: 'guild_text',
+        actor_role: 'owner',
+        is_thread: false,
       });
 
       logger.info(

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,8 +72,8 @@ export interface NewMessage {
 
 /**
  * チャンネルコールバック専用のメッセージ型。
- * NewMessage を拡張し、永続化されない Discord 固有のメタデータを付与する。
- * storeMessage には渡さず、onMessage コールバック内でのみ参照すること。
+ * NewMessage を拡張し、Discord 固有のメタデータを付与する。
+ * storeMessage に渡しても問題ないが、追加フィールドは DB 側で保存されない。
  */
 export interface InboundMessage extends NewMessage {
   place_type?: PlaceType;
@@ -122,7 +122,10 @@ export interface Channel {
 
 // チャネルが受信メッセージを配信するために使用するコールバック型。
 // InboundMessage は NewMessage のスーパーセットなので、既存ハンドラはそのまま使用できる。
-export type OnInboundMessage = (chatJid: string, message: InboundMessage) => void;
+export type OnInboundMessage = (
+  chatJid: string,
+  message: InboundMessage,
+) => void;
 
 // チャットのメタデータ検出用コールバック。
 // name はオプション — 名前をインラインで配信するチャネル（Telegram）はここに渡す。

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,14 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+}
+
+/**
+ * チャンネルコールバック専用のメッセージ型。
+ * NewMessage を拡張し、永続化されない Discord 固有のメタデータを付与する。
+ * storeMessage には渡さず、onMessage コールバック内でのみ参照すること。
+ */
+export interface InboundMessage extends NewMessage {
   place_type?: PlaceType;
   actor_role?: ActorRole;
   is_thread?: boolean;
@@ -112,8 +120,9 @@ export interface Channel {
   syncGroups?(force: boolean): Promise<void>;
 }
 
-// チャネルが受信メッセージを配信するために使用するコールバック型
-export type OnInboundMessage = (chatJid: string, message: NewMessage) => void;
+// チャネルが受信メッセージを配信するために使用するコールバック型。
+// InboundMessage は NewMessage のスーパーセットなので、既存ハンドラはそのまま使用できる。
+export type OnInboundMessage = (chatJid: string, message: InboundMessage) => void;
 
 // チャットのメタデータ検出用コールバック。
 // name はオプション — 名前をインラインで配信するチャネル（Telegram）はここに渡す。

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,8 +55,8 @@ export interface RegisteredGroup {
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // デフォルト: グループの場合は true、個人チャットの場合は false
   isMain?: boolean; // メインコントロールグループの場合は true（トリガー不要、特権あり）
-  channelMode?: 'chat' | 'url_watch' | 'admin_control';
-  chatBehavior?: 'ambient_room_chat' | 'directed_help_chat';
+  channel_mode?: 'chat' | 'url_watch' | 'admin_control';
+  chat_behavior?: 'ambient_room_chat' | 'directed_help_chat';
 }
 
 export interface NewMessage {
@@ -68,9 +68,9 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
-  placeType?: PlaceType;
-  actorRole?: ActorRole;
-  isThread?: boolean;
+  place_type?: PlaceType;
+  actor_role?: ActorRole;
+  is_thread?: boolean;
 }
 
 export interface ScheduledTask {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,21 @@ export interface ContainerConfig {
   timeout?: number; // デフォルト: 300000 (5分)
 }
 
+// --- Discord 拡張型（VRC-AI-Bot 由来） ---
+
+/** メッセージの送信場所の種別 */
+export type PlaceType =
+  | 'guild_text'
+  | 'guild_announcement'
+  | 'chat_channel'
+  | 'admin_control_channel'
+  | 'public_thread'
+  | 'private_thread'
+  | 'forum_post_thread';
+
+/** ユーザーの権限ロール */
+export type ActorRole = 'owner' | 'admin' | 'user';
+
 export interface RegisteredGroup {
   name: string;
   folder: string;
@@ -40,6 +55,8 @@ export interface RegisteredGroup {
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // デフォルト: グループの場合は true、個人チャットの場合は false
   isMain?: boolean; // メインコントロールグループの場合は true（トリガー不要、特権あり）
+  channelMode?: 'chat' | 'url_watch' | 'admin_control';
+  chatBehavior?: 'ambient_room_chat' | 'directed_help_chat';
 }
 
 export interface NewMessage {
@@ -51,6 +68,9 @@ export interface NewMessage {
   timestamp: string;
   is_from_me?: boolean;
   is_bot_message?: boolean;
+  placeType?: PlaceType;
+  actorRole?: ActorRole;
+  isThread?: boolean;
 }
 
 export interface ScheduledTask {


### PR DESCRIPTION
## Summary
- `PlaceType`（7種）/ `ActorRole`（3種）の型定義を `src/types.ts` に追加
- `RegisteredGroup` に `channel_mode` / `chat_behavior` フィールドを追加（snake_case、将来のチャンネルモード分岐用）
- `NewMessage` のスーパーセットとして `InboundMessage` 型を追加。`place_type` / `actor_role` / `is_thread` を保持するが、DB永続化（storeMessage）では保存されない
- Discord 受信メッセージ生成時に `place_type='guild_text'`, `actor_role='owner'`, `is_thread=false` でハードコード（将来の動的解決の基盤）
- `OnInboundMessage` コールバックは `InboundMessage` を受け取るよう変更（既存ハンドラとの互換性を維持）

## Test plan
- [x] `npm test -- src/channels/discord.test.ts` 全34テスト通過
- [x] `npm run build` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)