### PR TITLE
feat: isMain を GroupType に置き換え

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -422,7 +422,11 @@ async function runQuery(
   // グローバルメモリ（CLAUDE.md）を追加のシステムコンテキストとしてロード（全グループで共有）
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
-  const resolvedGroupType = containerInput.groupType ?? 'chat';
+  const allowedGroupTypes = new Set(['override', 'main', 'chat', 'thread']);
+  const rawGroupType = containerInput.groupType ?? 'chat';
+  const resolvedGroupType = allowedGroupTypes.has(rawGroupType)
+    ? rawGroupType
+    : 'chat';
   const isPrivileged =
     resolvedGroupType === 'main' || resolvedGroupType === 'override';
   if (!isPrivileged && fs.existsSync(globalClaudeMdPath)) {

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,7 +16,11 @@
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  HookCallback,
+  PreCompactHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
 interface ContainerInput {
@@ -27,6 +31,8 @@ interface ContainerInput {
   // NOTE: ホスト側の GroupType (src/types.ts) と同期が必要。
   // コンテナはホストのソースを import できないため、ここで再定義している。
   // GroupType を変更した場合はこのファイルも更新すること。
+  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため
+  // ホスト・コンテナは常にセットで更新する運用）。
   groupType?: 'override' | 'main' | 'chat' | 'thread';
   isScheduledTask?: boolean;
   assistantName?: string;
@@ -91,7 +97,9 @@ class MessageStream {
         yield this.queue.shift()!;
       }
       if (this.done) return;
-      await new Promise<void>(r => { this.waiting = r; });
+      await new Promise<void>((r) => {
+        this.waiting = r;
+      });
       this.waiting = null;
     }
   }
@@ -101,7 +109,9 @@ async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
     process.stdin.on('end', () => resolve(data));
     process.stdin.on('error', reject);
   });
@@ -120,7 +130,10 @@ function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
 }
 
-function getSessionSummary(sessionId: string, transcriptPath: string): string | null {
+function getSessionSummary(
+  sessionId: string,
+  transcriptPath: string,
+): string | null {
   const projectDir = path.dirname(transcriptPath);
   const indexPath = path.join(projectDir, 'sessions-index.json');
 
@@ -130,13 +143,17 @@ function getSessionSummary(sessionId: string, transcriptPath: string): string | 
   }
 
   try {
-    const index: SessionsIndex = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-    const entry = index.entries.find(e => e.sessionId === sessionId);
+    const index: SessionsIndex = JSON.parse(
+      fs.readFileSync(indexPath, 'utf-8'),
+    );
+    const entry = index.entries.find((e) => e.sessionId === sessionId);
     if (entry?.summary) {
       return entry.summary;
     }
   } catch (err) {
-    log(`セッションインデックスの読み込みに失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+    log(
+      `セッションインデックスの読み込みに失敗しました: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   return null;
@@ -175,12 +192,18 @@ function createPreCompactHook(assistantName?: string): HookCallback {
       const filename = `${date}-${name}.md`;
       const filePath = path.join(conversationsDir, filename);
 
-      const markdown = formatTranscriptMarkdown(messages, summary, assistantName);
+      const markdown = formatTranscriptMarkdown(
+        messages,
+        summary,
+        assistantName,
+      );
       fs.writeFileSync(filePath, markdown);
 
       log(`会話を ${filePath} にアーカイブしました`);
     } catch (err) {
-      log(`履歴のアーカイブに失敗しました: ${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `履歴のアーカイブに失敗しました: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     return {};
@@ -213,9 +236,12 @@ function parseTranscript(content: string): ParsedMessage[] {
     try {
       const entry = JSON.parse(line);
       if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string'
-          ? entry.message.content
-          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content
+                .map((c: { text?: string }) => c.text || '')
+                .join('');
         if (text) messages.push({ role: 'user', content: text });
       } else if (entry.type === 'assistant' && entry.message?.content) {
         const textParts = entry.message.content
@@ -224,22 +250,26 @@ function parseTranscript(content: string): ParsedMessage[] {
         const text = textParts.join('');
         if (text) messages.push({ role: 'assistant', content: text });
       }
-    } catch {
-    }
+    } catch {}
   }
 
   return messages;
 }
 
-function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+function formatTranscriptMarkdown(
+  messages: ParsedMessage[],
+  title?: string | null,
+  assistantName?: string,
+): string {
   const now = new Date();
-  const formatDateTime = (d: Date) => d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  });
+  const formatDateTime = (d: Date) =>
+    d.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
 
   const lines: string[] = [];
   lines.push(`# ${title || 'Conversation'}`);
@@ -250,10 +280,11 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
   lines.push('');
 
   for (const msg of messages) {
-    const sender = msg.role === 'user' ? 'User' : (assistantName || 'Assistant');
-    const content = msg.content.length > 2000
-      ? msg.content.slice(0, 2000) + '...'
-      : msg.content;
+    const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
+    const content =
+      msg.content.length > 2000
+        ? msg.content.slice(0, 2000) + '...'
+        : msg.content;
     lines.push(`**${sender}**: ${content}`);
     lines.push('');
   }
@@ -266,7 +297,11 @@ function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | nu
  */
 function shouldClose(): boolean {
   if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
-    try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* 無視 */ }
+    try {
+      fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+    } catch {
+      /* 無視 */
+    }
     return true;
   }
   return false;
@@ -279,8 +314,9 @@ function shouldClose(): boolean {
 function drainIpcInput(): string[] {
   try {
     fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
-    const files = fs.readdirSync(IPC_INPUT_DIR)
-      .filter(f => f.endsWith('.json'))
+    const files = fs
+      .readdirSync(IPC_INPUT_DIR)
+      .filter((f) => f.endsWith('.json'))
       .sort();
 
     const messages: string[] = [];
@@ -293,13 +329,21 @@ function drainIpcInput(): string[] {
           messages.push(data.text);
         }
       } catch (err) {
-        log(`入力ファイル ${file} の処理に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
-        try { fs.unlinkSync(filePath); } catch { /* 無視 */ }
+        log(
+          `入力ファイル ${file} の処理に失敗しました: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        try {
+          fs.unlinkSync(filePath);
+        } catch {
+          /* 無視 */
+        }
       }
     }
     return messages;
   } catch (err) {
-    log(`IPC 吸い出しエラー: ${err instanceof Error ? err.message : String(err)}`);
+    log(
+      `IPC 吸い出しエラー: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return [];
   }
 }
@@ -339,7 +383,11 @@ async function runQuery(
   containerInput: ContainerInput,
   sdkEnv: Record<string, string | undefined>,
   resumeAt?: string,
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
+): Promise<{
+  newSessionId?: string;
+  lastAssistantUuid?: string;
+  closedDuringQuery: boolean;
+}> {
   const stream = new MessageStream();
   stream.push(prompt);
 
@@ -349,7 +397,9 @@ async function runQuery(
   const pollIpcDuringQuery = () => {
     if (!ipcPolling) return;
     if (shouldClose()) {
-      log('クエリ実行中にクローズセンチネルを検出しました。ストリームを終了します');
+      log(
+        'クエリ実行中にクローズセンチネルを検出しました。ストリームを終了します',
+      );
       closedDuringQuery = true;
       stream.end();
       ipcPolling = false;
@@ -373,7 +423,8 @@ async function runQuery(
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
   const resolvedGroupType = containerInput.groupType ?? 'chat';
-  const isPrivileged = resolvedGroupType === 'main' || resolvedGroupType === 'override';
+  const isPrivileged =
+    resolvedGroupType === 'main' || resolvedGroupType === 'override';
   if (!isPrivileged && fs.existsSync(globalClaudeMdPath)) {
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
@@ -402,17 +453,32 @@ async function runQuery(
       resume: sessionId,
       resumeSessionAt: resumeAt,
       systemPrompt: globalClaudeMd
-        ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
+        ? {
+            type: 'preset' as const,
+            preset: 'claude_code' as const,
+            append: globalClaudeMd,
+          }
         : undefined,
       allowedTools: [
         'Bash',
-        'Read', 'Write', 'Edit', 'Glob', 'Grep',
-        'WebSearch', 'WebFetch',
-        'Task', 'TaskOutput', 'TaskStop',
-        'TeamCreate', 'TeamDelete', 'SendMessage',
-        'TodoWrite', 'ToolSearch', 'Skill',
+        'Read',
+        'Write',
+        'Edit',
+        'Glob',
+        'Grep',
+        'WebSearch',
+        'WebFetch',
+        'Task',
+        'TaskOutput',
+        'TaskStop',
+        'TeamCreate',
+        'TeamDelete',
+        'SendMessage',
+        'TodoWrite',
+        'ToolSearch',
+        'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        'mcp__nanoclaw__*',
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -431,12 +497,17 @@ async function runQuery(
         },
       },
       hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
+        PreCompact: [
+          { hooks: [createPreCompactHook(containerInput.assistantName)] },
+        ],
       },
-    }
+    },
   })) {
     messageCount++;
-    const msgType = message.type === 'system' ? `system/${(message as { subtype?: string }).subtype}` : message.type;
+    const msgType =
+      message.type === 'system'
+        ? `system/${(message as { subtype?: string }).subtype}`
+        : message.type;
     log(`[メッセージ #${messageCount}] type=${msgType}`);
 
     if (message.type === 'assistant' && 'uuid' in message) {
@@ -448,25 +519,39 @@ async function runQuery(
       log(`セッション初期化完了: ${newSessionId}`);
     }
 
-    if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
-      const tn = message as { task_id: string; status: string; summary: string };
-      log(`タスク通知: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`);
+    if (
+      message.type === 'system' &&
+      (message as { subtype?: string }).subtype === 'task_notification'
+    ) {
+      const tn = message as {
+        task_id: string;
+        status: string;
+        summary: string;
+      };
+      log(
+        `タスク通知: task=${tn.task_id} status=${tn.status} summary=${tn.summary}`,
+      );
     }
 
     if (message.type === 'result') {
       resultCount++;
-      const textResult = 'result' in message ? (message as { result?: string }).result : null;
-      log(`結果 #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      const textResult =
+        'result' in message ? (message as { result?: string }).result : null;
+      log(
+        `結果 #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
+      );
       writeOutput({
         status: 'success',
         result: textResult || null,
-        newSessionId
+        newSessionId,
       });
     }
   }
 
   ipcPolling = false;
-  log(`クエリ終了。メッセージ数: ${messageCount}, 結果数: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
+  log(
+    `クエリ終了。メッセージ数: ${messageCount}, 結果数: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`,
+  );
   return { newSessionId, lastAssistantUuid, closedDuringQuery };
 }
 
@@ -476,13 +561,17 @@ async function main(): Promise<void> {
   try {
     const stdinData = await readStdin();
     containerInput = JSON.parse(stdinData);
-    try { fs.unlinkSync('/tmp/input.json'); } catch { /* 存在しない可能性あり */ }
+    try {
+      fs.unlinkSync('/tmp/input.json');
+    } catch {
+      /* 存在しない可能性あり */
+    }
     log(`グループ用の入力を受信しました: ${containerInput.groupFolder}`);
   } catch (err) {
     writeOutput({
       status: 'error',
       result: null,
-      error: `入力のパースに失敗しました: ${err instanceof Error ? err.message : String(err)}`
+      error: `入力のパースに失敗しました: ${err instanceof Error ? err.message : String(err)}`,
     });
     process.exit(1);
   }
@@ -498,7 +587,11 @@ async function main(): Promise<void> {
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
   // 以前のコンテナ実行から残っている古い _close センチネルをクリーンアップ
-  try { fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL); } catch { /* 無視 */ }
+  try {
+    fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
+  } catch {
+    /* 無視 */
+  }
 
   // 初期プロンプトを構築（保留中の IPC メッセージも吸い出す）
   let prompt = containerInput.prompt;
@@ -507,7 +600,9 @@ async function main(): Promise<void> {
   }
   const pending = drainIpcInput();
   if (pending.length > 0) {
-    log(`${pending.length} 件の保留中 IPC メッセージを初期プロンプトに統合します`);
+    log(
+      `${pending.length} 件の保留中 IPC メッセージを初期プロンプトに統合します`,
+    );
     prompt += '\n' + pending.join('\n');
   }
 
@@ -515,9 +610,18 @@ async function main(): Promise<void> {
   let resumeAt: string | undefined;
   try {
     while (true) {
-      log(`クエリを開始します (セッション: ${sessionId || '新規'}, resumeAt: ${resumeAt || '最新'})...`);
+      log(
+        `クエリを開始します (セッション: ${sessionId || '新規'}, resumeAt: ${resumeAt || '最新'})...`,
+      );
 
-      const queryResult = await runQuery(prompt, sessionId, mcpServerPath, containerInput, sdkEnv, resumeAt);
+      const queryResult = await runQuery(
+        prompt,
+        sessionId,
+        mcpServerPath,
+        containerInput,
+        sdkEnv,
+        resumeAt,
+      );
       if (queryResult.newSessionId) {
         sessionId = queryResult.newSessionId;
       }
@@ -545,7 +649,9 @@ async function main(): Promise<void> {
         break;
       }
 
-      log(`新しいメッセージを受信しました (${nextMessage.length} 文字)。新しいクエリを開始します`);
+      log(
+        `新しいメッセージを受信しました (${nextMessage.length} 文字)。新しいクエリを開始します`,
+      );
       prompt = nextMessage;
     }
   } catch (err) {
@@ -555,7 +661,7 @@ async function main(): Promise<void> {
       status: 'error',
       result: null,
       newSessionId: sessionId,
-      error: errorMessage
+      error: errorMessage,
     });
     process.exit(1);
   }

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -24,7 +24,9 @@ interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
+  /** @deprecated groupType を使用すること */
   isMain: boolean;
+  groupType?: 'override' | 'main' | 'chat' | 'thread';
   isScheduledTask?: boolean;
   assistantName?: string;
 }
@@ -369,7 +371,9 @@ async function runQuery(
   // グローバルメモリ（CLAUDE.md）を追加のシステムコンテキストとしてロード（全グループで共有）
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
-  if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
+  const resolvedGroupType = containerInput.groupType ?? (containerInput.isMain ? 'main' : 'chat');
+  const isPrivileged = resolvedGroupType === 'main' || resolvedGroupType === 'override';
+  if (!isPrivileged && fs.existsSync(globalClaudeMdPath)) {
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
 
@@ -420,7 +424,8 @@ async function runQuery(
           env: {
             NANOCLAW_CHAT_JID: containerInput.chatJid,
             NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+            NANOCLAW_IS_MAIN: isPrivileged ? '1' : '0',
+            NANOCLAW_GROUP_TYPE: resolvedGroupType,
           },
         },
       },

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -28,11 +28,9 @@ interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
-  // NOTE: ホスト側の GroupType (src/types.ts) と同期が必要。
-  // コンテナはホストのソースを import できないため、ここで再定義している。
+  // NOTE: ホスト側の GroupType (src/types.ts) と同期が必要。コンテナはホストのソースを import できないため、ここで再定義している。
   // GroupType を変更した場合はこのファイルも更新すること。
-  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため
-  // ホスト・コンテナは常にセットで更新する運用）。
+  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのためホスト・コンテナは常にセットで更新する運用）。
   groupType?: 'override' | 'main' | 'chat' | 'thread';
   isScheduledTask?: boolean;
   assistantName?: string;
@@ -580,8 +578,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // 認証情報はホストの認証情報プロキシによって ANTHROPIC_BASE_URL 経由で注入されます。
-  // コンテナ環境には本物のシークレットは存在しません。
+  // 認証情報はホストの認証情報プロキシによって ANTHROPIC_BASE_URL 経由で注入されます。コンテナ環境には本物のシークレットは存在しません。
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -634,8 +631,7 @@ async function main(): Promise<void> {
       }
 
       // クエリ実行中に _close が消費された場合は即座に終了。
-      // セッション更新マーカーを出力しないでください（ホストのアイドルタイマーがリセットされ、
-      // 次の _close まで 30 分の遅延が発生するため）。
+      // セッション更新マーカーを出力しないでください（ホストのアイドルタイマーがリセットされ、次の _close まで 30 分の遅延が発生するため）。
       if (queryResult.closedDuringQuery) {
         log('クエリ実行中にクローズセンチネルが消費されました。終了します');
         break;

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -26,6 +26,9 @@ interface ContainerInput {
   chatJid: string;
   /** @deprecated groupType を使用すること */
   isMain: boolean;
+  // NOTE: ホスト側の GroupType (src/types.ts) と同期が必要。
+  // コンテナはホストのソースを import できないため、ここで再定義している。
+  // GroupType を変更した場合はこのファイルも更新すること。
   groupType?: 'override' | 'main' | 'chat' | 'thread';
   isScheduledTask?: boolean;
   assistantName?: string;

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -24,8 +24,6 @@ interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
-  /** @deprecated groupType を使用すること */
-  isMain: boolean;
   // NOTE: ホスト側の GroupType (src/types.ts) と同期が必要。
   // コンテナはホストのソースを import できないため、ここで再定義している。
   // GroupType を変更した場合はこのファイルも更新すること。
@@ -374,7 +372,7 @@ async function runQuery(
   // グローバルメモリ（CLAUDE.md）を追加のシステムコンテキストとしてロード（全グループで共有）
   const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
   let globalClaudeMd: string | undefined;
-  const resolvedGroupType = containerInput.groupType ?? (containerInput.isMain ? 'main' : 'chat');
+  const resolvedGroupType = containerInput.groupType ?? 'chat';
   const isPrivileged = resolvedGroupType === 'main' || resolvedGroupType === 'override';
   if (!isPrivileged && fs.existsSync(globalClaudeMdPath)) {
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -18,7 +18,13 @@ const TASKS_DIR = path.join(IPC_DIR, 'tasks');
 // 環境変数からのコンテキスト（エージェントランナーによって設定されます）
 const chatJid = process.env.NANOCLAW_CHAT_JID!;
 const groupFolder = process.env.NANOCLAW_GROUP_FOLDER!;
-const groupType = process.env.NANOCLAW_GROUP_TYPE ?? (process.env.NANOCLAW_IS_MAIN === '1' ? 'main' : 'chat');
+// NOTE: ホスト側の GroupType (src/types.ts) と同期が必要。
+// コンテナはホストのソースを import できないため、ここで再定義している。
+// GroupType を変更した場合はこのファイルも更新すること。
+const allowedGroupTypes = new Set(['override', 'main', 'chat', 'thread']);
+const rawGroupType = process.env.NANOCLAW_GROUP_TYPE;
+const groupTypeCandidate = rawGroupType ?? (process.env.NANOCLAW_IS_MAIN === '1' ? 'main' : 'chat');
+const groupType = allowedGroupTypes.has(groupTypeCandidate) ? groupTypeCandidate : 'chat';
 const isMain = groupType === 'main' || groupType === 'override';
 
 function writeIpcFile(dir: string, data: object): string {

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -134,7 +134,7 @@ server.tool(
       }
     }
 
-    // メイン以外のグループは自分自身に対してのみスケジュール可能
+    // 特権以外のグループは自分自身に対してのみスケジュール可能
     const targetJid = isPrivileged && args.target_group_jid ? args.target_group_jid : chatJid;
 
     const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -25,7 +25,7 @@ const allowedGroupTypes = new Set(['override', 'main', 'chat', 'thread']);
 const rawGroupType = process.env.NANOCLAW_GROUP_TYPE;
 const groupTypeCandidate = rawGroupType ?? (process.env.NANOCLAW_IS_MAIN === '1' ? 'main' : 'chat');
 const groupType = allowedGroupTypes.has(groupTypeCandidate) ? groupTypeCandidate : 'chat';
-const isMain = groupType === 'main' || groupType === 'override';
+const isPrivileged = groupType === 'main' || groupType === 'override';
 
 function writeIpcFile(dir: string, data: object): string {
   fs.mkdirSync(dir, { recursive: true });
@@ -135,7 +135,7 @@ server.tool(
     }
 
     // メイン以外のグループは自分自身に対してのみスケジュール可能
-    const targetJid = isMain && args.target_group_jid ? args.target_group_jid : chatJid;
+    const targetJid = isPrivileged && args.target_group_jid ? args.target_group_jid : chatJid;
 
     const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -173,7 +173,7 @@ server.tool(
 
       const allTasks = JSON.parse(fs.readFileSync(tasksFile, 'utf-8'));
 
-      const tasks = isMain
+      const tasks = isPrivileged
         ? allTasks
         : allTasks.filter((t: { groupFolder: string }) => t.groupFolder === groupFolder);
 
@@ -206,7 +206,7 @@ server.tool(
       type: 'pause_task',
       taskId: args.task_id,
       groupFolder,
-      isMain,
+      isPrivileged,
       timestamp: new Date().toISOString(),
     };
 
@@ -225,7 +225,7 @@ server.tool(
       type: 'resume_task',
       taskId: args.task_id,
       groupFolder,
-      isMain,
+      isPrivileged,
       timestamp: new Date().toISOString(),
     };
 
@@ -244,7 +244,7 @@ server.tool(
       type: 'cancel_task',
       taskId: args.task_id,
       groupFolder,
-      isMain,
+      isPrivileged,
       timestamp: new Date().toISOString(),
     };
 
@@ -291,7 +291,7 @@ server.tool(
       type: 'update_task',
       taskId: args.task_id,
       groupFolder,
-      isMain: String(isMain),
+      isPrivileged: String(isPrivileged),
       timestamp: new Date().toISOString(),
     };
     if (args.prompt !== undefined) data.prompt = args.prompt;
@@ -316,7 +316,7 @@ server.tool(
     trigger: z.string().describe('トリガーワード（例: "@Andy"）'),
   },
   async (args) => {
-    if (!isMain) {
+    if (!isPrivileged) {
       return {
         content: [{ type: 'text' as const, text: '新しいグループの登録はメイングループのみが可能です。' }],
         isError: true,

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -18,7 +18,8 @@ const TASKS_DIR = path.join(IPC_DIR, 'tasks');
 // 環境変数からのコンテキスト（エージェントランナーによって設定されます）
 const chatJid = process.env.NANOCLAW_CHAT_JID!;
 const groupFolder = process.env.NANOCLAW_GROUP_FOLDER!;
-const isMain = process.env.NANOCLAW_IS_MAIN === '1';
+const groupType = process.env.NANOCLAW_GROUP_TYPE ?? (process.env.NANOCLAW_IS_MAIN === '1' ? 'main' : 'chat');
+const isMain = groupType === 'main' || groupType === 'override';
 
 function writeIpcFile(dir: string, data: object): string {
   fs.mkdirSync(dir, { recursive: true });

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -97,7 +97,7 @@ server.tool(
     schedule_type: z.enum(['cron', 'interval', 'once']).describe('cron=特定の時刻に定期実行、interval=指定したミリ秒ごと、once=特定の時刻に一度だけ実行'),
     schedule_value: z.string().describe('cron: "*/5 * * * *" | interval: "300000" などのミリ秒 | once: "2026-02-01T15:30:00" などのローカルタイムスタンプ（Zサフィックス禁止！）'),
     context_mode: z.enum(['group', 'isolated']).default('group').describe('group=チャット履歴とメモリを使用して実行、isolated=新規セッション（プロンプトにコンテキストを含めること）'),
-    target_group_jid: z.string().optional().describe('(メイングループのみ) タスクをスケジュールする対象グループの JID。デフォルトは現在のグループ。'),
+    target_group_jid: z.string().optional().describe('(特権グループ（main/override）のみ) タスクをスケジュールする対象グループの JID。デフォルトは現在のグループ。'),
   },
   async (args) => {
     // IPC 書き出し前に schedule_value を検証
@@ -161,7 +161,7 @@ server.tool(
 
 server.tool(
   'list_tasks',
-  'スケジュールされているすべてのタスクを一覧表示します。メイングループからはすべてのタスクが表示されます。他のグループからは、そのグループ自身のタスクのみが表示されます。',
+  'スケジュールされているすべてのタスクを一覧表示します。特権グループ（main/override）からはすべてのタスクが表示されます。他のグループからは、そのグループ自身のタスクのみが表示されます。',
   {},
   async () => {
     const tasksFile = path.join(IPC_DIR, 'current_tasks.json');
@@ -302,7 +302,7 @@ server.tool(
 
 server.tool(
   'register_group',
-  `新しいチャット/グループを登録して、エージェントがそこでメッセージに応答できるようにします。メイングループのみが実行可能です。
+  `新しいチャット/グループを登録して、エージェントがそこでメッセージに応答できるようにします。特権グループ（main/override）のみが実行可能です。
 
 グループの JID を見つけるには available_groups.json を使用してください。フォルダ名はチャネルプレフィックス付きの "{channel}_{group-name}" 形式にする必要があります（例: "whatsapp_family-chat", "telegram_dev-team", "discord_general"）。グループ名の部分にはハイフン付きの小文字を使用してください。`,
   {
@@ -314,7 +314,7 @@ server.tool(
   async (args) => {
     if (!isPrivileged) {
       return {
-        content: [{ type: 'text' as const, text: '新しいグループの登録はメイングループのみが可能です。' }],
+        content: [{ type: 'text' as const, text: '新しいグループの登録は特権グループ（main/override）のみが可能です。' }],
         isError: true,
       };
     }

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -206,7 +206,6 @@ server.tool(
       type: 'pause_task',
       taskId: args.task_id,
       groupFolder,
-      isPrivileged,
       timestamp: new Date().toISOString(),
     };
 
@@ -225,7 +224,6 @@ server.tool(
       type: 'resume_task',
       taskId: args.task_id,
       groupFolder,
-      isPrivileged,
       timestamp: new Date().toISOString(),
     };
 
@@ -244,7 +242,6 @@ server.tool(
       type: 'cancel_task',
       taskId: args.task_id,
       groupFolder,
-      isPrivileged,
       timestamp: new Date().toISOString(),
     };
 
@@ -291,7 +288,6 @@ server.tool(
       type: 'update_task',
       taskId: args.task_id,
       groupFolder,
-      isPrivileged: String(isPrivileged),
       timestamp: new Date().toISOString(),
     };
     if (args.prompt !== undefined) data.prompt = args.prompt;

--- a/docs/thread-based-architecture/is-main-removal.md
+++ b/docs/thread-based-architecture/is-main-removal.md
@@ -1,0 +1,88 @@
+# is_main カラム完全削除の計画
+
+## 現状
+
+`registered_groups` テーブルには `is_main` (INTEGER) と `group_type` (TEXT) の2カラムが共存している。
+`group_type` は feat/group-type で追加された新しい権限管理の主カラムであり、`is_main` はレガシー。
+
+### 現在の依存箇所
+
+| 箇所 | 用途 | 状態 |
+|------|------|------|
+| `src/db.ts` `parseGroupType()` | `group_type = NULL` の行を `is_main` で救済 | NULL 限定のフォールバックとして残存 |
+| `src/db.ts` `setRegisteredGroup()` | `is_main` カラムへの書き込み | 新規登録・更新のたびに同期 |
+| DB スキーマ | `is_main INTEGER DEFAULT 0` カラム | 残存 |
+
+---
+
+## 削除手順
+
+### Step 1: DB マイグレーション追加（`src/db.ts`）
+
+既存のマイグレーションパターン（try-catch）に従い追加する。
+
+```ts
+// NULL な group_type を is_main から救済してからカラムを削除
+try {
+  database.exec(`
+    UPDATE registered_groups
+    SET group_type = 'main'
+    WHERE is_main = 1 AND group_type IS NULL
+  `);
+  database.exec(
+    `ALTER TABLE registered_groups DROP COLUMN is_main`,
+  );
+} catch {
+  /* カラムはすでに削除済み */
+}
+```
+
+> **注意:** SQLite 3.35.0 (2021-03-12) 以降が必要。
+> `better-sqlite3` がバンドルするバージョンを事前に確認すること。
+> 確認コマンド:
+> ```bash
+> node -e "const db = require('better-sqlite3')(':memory:'); console.log(db.prepare('SELECT sqlite_version()').pluck().get())"
+> ```
+
+### Step 2: `parseGroupType()` の簡素化（`src/db.ts`）
+
+```ts
+function parseGroupType(groupType: string | null): GroupType {
+  if (groupType == null) return 'chat'; // is_main フォールバック不要
+  if (VALID_GROUP_TYPES.has(groupType)) return groupType as GroupType;
+  logger.warn({ groupType }, 'Invalid group_type in DB; falling back to "chat".');
+  return 'chat';
+}
+```
+
+呼び出し側も `parseGroupType(row.group_type)` に変更（`row.is_main` 参照を削除）。
+
+### Step 3: `setRegisteredGroup()` の簡素化（`src/db.ts`）
+
+INSERT OR REPLACE 文から `is_main` カラムを削除:
+
+```sql
+INSERT OR REPLACE INTO registered_groups
+  (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, group_type)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+```
+
+`run()` の引数からも `is_main` 相当の値を削除する。
+
+### Step 4: 型定義の整理（`src/types.ts`）
+
+`RegisteredGroup` に `isMain` が残っていないか確認し、あれば削除する。
+
+---
+
+## リスク
+
+- **クローンして自己ホストしているユーザーへの影響:** 実行環境の DB で `group_type = NULL` かつ `is_main = 1` な行があると、Step 1 のマイグレーションで `'main'` に昇格してから DROP されるため、データは保全される。
+- **SQLite バージョン制約:** 3.35.0 未満では `DROP COLUMN` が使えない。その場合はテーブル再作成方式（CREATE new → INSERT SELECT → DROP old → RENAME）が必要。
+
+---
+
+## 実施判断
+
+- 自分のサーバーのみで使っている場合: いつでも実施可
+- パブリックリポジトリとして公開中の場合: クローン使用者への影響が軽微であることを確認してから実施

--- a/setup/register.ts
+++ b/setup/register.ts
@@ -20,7 +20,7 @@ interface RegisterArgs {
   folder: string;
   channel: string;
   requiresTrigger: boolean;
-  isMain: boolean;
+  type: 'main' | 'chat';
   assistantName: string;
 }
 
@@ -32,7 +32,7 @@ function parseArgs(args: string[]): RegisterArgs {
     folder: '',
     channel: 'whatsapp', // 後方互換性: リファクタリング前のインストールでは --channel が省略されます
     requiresTrigger: true,
-    isMain: false,
+    type: 'chat',
     assistantName: 'Andy',
   };
 
@@ -57,7 +57,7 @@ function parseArgs(args: string[]): RegisterArgs {
         result.requiresTrigger = false;
         break;
       case '--is-main':
-        result.isMain = true;
+        result.type = 'main';
         break;
       case '--assistant-name':
         result.assistantName = args[++i] || 'Andy';
@@ -106,7 +106,7 @@ export async function run(args: string[]): Promise<void> {
     trigger: parsed.trigger,
     added_at: new Date().toISOString(),
     requiresTrigger: parsed.requiresTrigger,
-    isMain: parsed.isMain,
+    type: parsed.type,
   });
 
   logger.info('SQLite に登録情報を書き込みました');

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -101,6 +101,7 @@ const testInput = {
   groupFolder: 'test-group',
   chatJid: 'test@g.us',
   isMain: false,
+  groupType: 'chat' as const,
 };
 
 function emitOutputMarker(

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -100,7 +100,6 @@ const testInput = {
   prompt: 'Hello',
   groupFolder: 'test-group',
   chatJid: 'test@g.us',
-  isMain: false,
   groupType: 'chat' as const,
 };
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -39,8 +39,6 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
-  /** @deprecated groupType を使用すること */
-  isMain: boolean;
   groupType: GroupType;
   isScheduledTask?: boolean;
   assistantName?: string;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -688,7 +688,7 @@ export function writeTasksSnapshot(
   const groupIpcDir = resolveGroupIpcPath(groupFolder);
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
-  // メイングループはすべてのタスクを表示でき、他は自身のタスクのみを表示できる
+  // 特権グループ（main/override）はすべてのタスクを表示でき、非特権グループは自身のタスクのみを表示できる
   const filteredTasks = isPrivileged
     ? tasks
     : tasks.filter((t) => t.groupFolder === groupFolder);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -27,7 +27,8 @@ import {
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
-import { RegisteredGroup } from './types.js';
+import { getDefaultAllowedTools, resolveGroupType } from './group-type.js';
+import { GroupType, RegisteredGroup } from './types.js';
 
 // 堅牢な出力パースのためのセンチネルマーカー (agent-runner と一致させる必要があります)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -38,7 +39,9 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
+  /** @deprecated groupType を使用すること */
   isMain: boolean;
+  groupType: GroupType;
   isScheduledTask?: boolean;
   assistantName?: string;
 }
@@ -58,13 +61,14 @@ interface VolumeMount {
 
 function buildVolumeMounts(
   group: RegisteredGroup,
-  isMain: boolean,
+  groupType: GroupType,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
   const groupDir = resolveGroupFolderPath(group.folder);
+  const isPrivileged = groupType === 'main' || groupType === 'override';
 
-  if (isMain) {
+  if (isPrivileged) {
     // メイングループにはプロジェクトルートを読み取り専用でマウントします。
     // エージェントが必要とする書き込み可能なパス（グループフォルダ、IPC、.claude/）は、
     // 以下で個別にマウントされます。読み取り専用にすることで、エージェントが
@@ -125,26 +129,27 @@ function buildVolumeMounts(
   fs.mkdirSync(groupSessionsDir, { recursive: true });
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
   if (!fs.existsSync(settingsFile)) {
-    fs.writeFileSync(
-      settingsFile,
-      JSON.stringify(
-        {
-          env: {
-            // エージェントスウォーム（サブエージェントのオーケストレーション）を有効にする
-            // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
-            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-            // 追加マウントされたディレクトリから CLAUDE.md を読み込む
-            // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
-            CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-            // Claude のメモリ機能を有効にする（セッション間でユーザー設定を永続化）
-            // https://code.claude.com/docs/en/memory#manage-auto-memory
-            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-          },
-        },
-        null,
-        2,
-      ) + '\n',
-    );
+    const allowedTools = getDefaultAllowedTools(groupType);
+    const settingsContent: Record<string, unknown> = {
+      env: {
+        // エージェントスウォーム（サブエージェントのオーケストレーション）を有効にする
+        // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+        // 追加マウントされたディレクトリから CLAUDE.md を読み込む
+        // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+        CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+        // Claude のメモリ機能を有効にする（セッション間でユーザー設定を永続化）
+        // https://code.claude.com/docs/en/memory#manage-auto-memory
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+      },
+    };
+    if (allowedTools !== undefined) {
+      settingsContent.permissions = {
+        allow: allowedTools,
+        deny: [],
+      };
+    }
+    fs.writeFileSync(settingsFile, JSON.stringify(settingsContent, null, 2) + '\n');
   }
 
   // container/skills/ から各グループ의 .claude/skills/ にスキルを同期
@@ -205,7 +210,7 @@ function buildVolumeMounts(
     const validatedMounts = validateAdditionalMounts(
       group.containerConfig.additionalMounts,
       group.name,
-      isMain,
+      isPrivileged,
     );
     mounts.push(...validatedMounts);
   }
@@ -276,7 +281,7 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
+  const mounts = buildVolumeMounts(group, input.groupType);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
   const containerArgs = buildContainerArgs(mounts, containerName);
@@ -299,7 +304,7 @@ export async function runContainerAgent(
       group: group.name,
       containerName,
       mountCount: mounts.length,
-      isMain: input.isMain,
+      groupType: input.groupType,
     },
     'Spawning container agent',
   );
@@ -493,7 +498,7 @@ export async function runContainerAgent(
         `=== Container Run Log ===`,
         `Timestamp: ${new Date().toISOString()}`,
         `Group: ${group.name}`,
-        `IsMain: ${input.isMain}`,
+        `GroupType: ${input.groupType}`,
         `Duration: ${duration}ms`,
         `Exit Code: ${code}`,
         `Stdout Truncated: ${stdoutTruncated}`,
@@ -645,7 +650,7 @@ export async function runContainerAgent(
 
 export function writeTasksSnapshot(
   groupFolder: string,
-  isMain: boolean,
+  isPrivileged: boolean,
   tasks: Array<{
     id: string;
     groupFolder: string;
@@ -661,7 +666,7 @@ export function writeTasksSnapshot(
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   // メイングループはすべてのタスクを表示でき、他は自身のタスクのみを表示できる
-  const filteredTasks = isMain
+  const filteredTasks = isPrivileged
     ? tasks
     : tasks.filter((t) => t.groupFolder === groupFolder);
 
@@ -683,7 +688,7 @@ export interface AvailableGroup {
  */
 export function writeGroupsSnapshot(
   groupFolder: string,
-  isMain: boolean,
+  isPrivileged: boolean,
   groups: AvailableGroup[],
   registeredJids: Set<string>,
 ): void {
@@ -691,7 +696,7 @@ export function writeGroupsSnapshot(
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   // メイングループはすべてのグループを表示でき、他は何も表示できない（グループをアクティブ化できないため）
-  const visibleGroups = isMain ? groups : [];
+  const visibleGroups = isPrivileged ? groups : [];
 
   const groupsFile = path.join(groupIpcDir, 'available_groups.json');
   fs.writeFileSync(

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -39,7 +39,7 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
-  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため
+  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため、
   // ホスト・コンテナは常にセットで更新する運用）。
   groupType: GroupType;
   isScheduledTask?: boolean;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -145,7 +145,10 @@ function buildVolumeMounts(
   let settingsContent: Record<string, unknown> = {};
   if (fs.existsSync(settingsFile)) {
     try {
-      settingsContent = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
+      const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        settingsContent = parsed as Record<string, unknown>;
+      }
     } catch {
       // パース失敗時は空オブジェクトから始める（既存 env は失われるが壊れたファイルより安全）
     }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -128,32 +128,41 @@ function buildVolumeMounts(
   );
   fs.mkdirSync(groupSessionsDir, { recursive: true });
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
-  if (!fs.existsSync(settingsFile)) {
-    const allowedTools = getDefaultAllowedTools(groupType);
-    const settingsContent: Record<string, unknown> = {
-      env: {
-        // エージェントスウォーム（サブエージェントのオーケストレーション）を有効にする
-        // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
-        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-        // 追加マウントされたディレクトリから CLAUDE.md を読み込む
-        // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
-        CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-        // Claude のメモリ機能を有効にする（セッション間でユーザー設定を永続化）
-        // https://code.claude.com/docs/en/memory#manage-auto-memory
-        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-      },
-    };
-    if (allowedTools !== undefined) {
-      settingsContent.permissions = {
-        allow: allowedTools,
-        deny: [],
-      };
+  // settings.json が存在する場合は読み込む、存在しない場合は空オブジェクトから始める
+  let settingsContent: Record<string, unknown> = {};
+  if (fs.existsSync(settingsFile)) {
+    try {
+      settingsContent = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
+    } catch {
+      // 読み込み失敗時は空オブジェクトから始める
     }
-    fs.writeFileSync(
-      settingsFile,
-      JSON.stringify(settingsContent, null, 2) + '\n',
-    );
+  } else {
+    // 新規作成時のみ env セクションを設定する
+    settingsContent.env = {
+      // エージェントスウォーム（サブエージェントのオーケストレーション）を有効にする
+      // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+      // 追加マウントされたディレクトリから CLAUDE.md を読み込む
+      // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+      CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+      // Claude のメモリ機能を有効にする（セッション間でユーザー設定を永続化）
+      // https://code.claude.com/docs/en/memory#manage-auto-memory
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+    };
   }
+  // permissions を groupType に基づいて常に同期する
+  // （既存環境のアップグレードや groupType 変更時も反映されるようにするため）
+  const allowedTools = getDefaultAllowedTools(groupType);
+  if (allowedTools !== undefined) {
+    settingsContent.permissions = { allow: allowedTools, deny: [] };
+  } else {
+    // main/override: permissions 制限なし → フィールドを削除
+    delete settingsContent.permissions;
+  }
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify(settingsContent, null, 2) + '\n',
+  );
 
   // container/skills/ から各グループ의 .claude/skills/ にスキルを同期
   const skillsSrc = path.join(process.cwd(), 'container', 'skills');

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -149,7 +149,10 @@ function buildVolumeMounts(
         deny: [],
       };
     }
-    fs.writeFileSync(settingsFile, JSON.stringify(settingsContent, null, 2) + '\n');
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify(settingsContent, null, 2) + '\n',
+    );
   }
 
   // container/skills/ から各グループ의 .claude/skills/ にスキルを同期

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -162,7 +162,12 @@ function buildVolumeMounts(
     !Array.isArray(settingsContent.env)
       ? (settingsContent.env as Record<string, unknown>)
       : {};
-  settingsContent.env = { ...defaultSettingsEnv, ...existingEnv };
+  const sanitizedExistingEnv: Record<string, string> = Object.fromEntries(
+    Object.entries(existingEnv).filter(
+      (e): e is [string, string] => typeof e[1] === 'string',
+    ),
+  );
+  settingsContent.env = { ...defaultSettingsEnv, ...sanitizedExistingEnv };
   // permissions を groupType に基づいて常に同期する
   // （既存環境のアップグレードや groupType 変更時も反映されるようにするため）
   const allowedTools = getDefaultAllowedTools(groupType);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -27,7 +27,7 @@ import {
 } from './container-runtime.js';
 import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
-import { getDefaultAllowedTools, resolveGroupType } from './group-type.js';
+import { getDefaultAllowedTools } from './group-type.js';
 import { GroupType, RegisteredGroup } from './types.js';
 
 // 堅牢な出力パースのためのセンチネルマーカー (agent-runner と一致させる必要があります)
@@ -39,6 +39,8 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
+  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため
+  // ホスト・コンテナは常にセットで更新する運用）。
   groupType: GroupType;
   isScheduledTask?: boolean;
   assistantName?: string;
@@ -126,28 +128,38 @@ function buildVolumeMounts(
   );
   fs.mkdirSync(groupSessionsDir, { recursive: true });
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
-  // settings.json が存在する場合は読み込む、存在しない場合は空オブジェクトから始める
+  const defaultSettingsEnv: Record<string, string> = {
+    // エージェントスウォーム（サブエージェントのオーケストレーション）を有効にする
+    // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
+    CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+    // 追加マウントされたディレクトリから CLAUDE.md を読み込む
+    // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
+    CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
+    // Claude のメモリ機能を有効にする（セッション間でユーザー設定を永続化）
+    // https://code.claude.com/docs/en/memory#manage-auto-memory
+    CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+  };
+
+  // settings.json が存在する場合は読み込む、存在しない場合やパース失敗時は
+  // 「ファイルが無い」と同様に空オブジェクトから始め、後で必須 env を補完する
   let settingsContent: Record<string, unknown> = {};
   if (fs.existsSync(settingsFile)) {
     try {
       settingsContent = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
     } catch {
-      // 読み込み失敗時は空オブジェクトから始める
+      // パース失敗時は空オブジェクトから始める（既存 env は失われるが壊れたファイルより安全）
     }
-  } else {
-    // 新規作成時のみ env セクションを設定する
-    settingsContent.env = {
-      // エージェントスウォーム（サブエージェントのオーケストレーション）を有効にする
-      // https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions
-      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-      // 追加マウントされたディレクトリから CLAUDE.md を読み込む
-      // https://code.claude.com/docs/en/memory#load-memory-from-additional-directories
-      CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-      // Claude のメモリ機能を有効にする（セッション間でユーザー設定を永続化）
-      // https://code.claude.com/docs/en/memory#manage-auto-memory
-      CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-    };
   }
+
+  // env はデフォルト値をベースに既存値で上書きする
+  // （新規作成・パース失敗・既存ファイルいずれの場合も CLAUDE_CODE_* フラグが必ず設定される）
+  const existingEnv =
+    settingsContent.env &&
+    typeof settingsContent.env === 'object' &&
+    !Array.isArray(settingsContent.env)
+      ? (settingsContent.env as Record<string, unknown>)
+      : {};
+  settingsContent.env = { ...defaultSettingsEnv, ...existingEnv };
   // permissions を groupType に基づいて常に同期する
   // （既存環境のアップグレードや groupType 変更時も反映されるようにするため）
   const allowedTools = getDefaultAllowedTools(groupType);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -150,7 +150,7 @@ function buildVolumeMounts(
       }
     } catch (err) {
       logger.warn(
-        { group: group.folder, settingsFile, error: err },
+        { group: group.folder, settingsFile, err },
         'Failed to parse settings.json; starting from empty object (existing user settings lost)',
       );
     }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -39,8 +39,7 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
-  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため、
-  // ホスト・コンテナは常にセットで更新する運用）。
+  // NOTE: isMain (boolean) は意図的に削除。後方互換性は不要（個人プロジェクトのため、ホスト・コンテナは常にセットで更新する運用）。
   groupType: GroupType;
   isScheduledTask?: boolean;
   assistantName?: string;
@@ -211,9 +210,7 @@ function buildVolumeMounts(
     readonly: false,
   });
 
-  // agent-runner のソースをグループごとの書き込み可能な場所にコピーし、
-  // エージェントが他のグループに影響を与えずにカスタマイズ（ツールの追加、
-  // 動作の変更）できるようにします。コンテナ起動時に entrypoint.sh を介して再コンパイルされます。
+  // agent-runner のソースをグループごとの書き込み可能な場所にコピーし、エージェントが他のグループに影響を与えずにカスタマイズ（ツールの追加、動作の変更）できるようにします。コンテナ起動時に entrypoint.sh を介して再コンパイルされます。
   const agentRunnerSrc = path.join(
     projectRoot,
     'container',
@@ -265,8 +262,7 @@ function buildContainerArgs(
 
   // ホストの認証方法をプレースホルダー値でミラーリング
   // API キーモード: SDK は x-api-key を送信し、プロキシが本物のキーに置き換える
-  // OAuth モード:   SDK はプレースホルダー・トークンを一時的な API キーに交換し、
-  //               プロキシはその交換リクエストに実際の OAuth トークンを注入する
+  // OAuth モード:   SDK はプレースホルダー・トークンを一時的な API キーに交換し、プロキシはその交換リクエストに実際の OAuth トークンを注入する
   const authMode = detectAuthMode();
   if (authMode === 'api-key') {
     args.push('-e', 'ANTHROPIC_API_KEY=placeholder');
@@ -277,9 +273,7 @@ function buildContainerArgs(
   // ホストゲートウェイ解決のためのランタイム固有の引数
   args.push(...hostGatewayArgs());
 
-  // バインドマウントされたファイルにアクセスできるよう、ホストユーザーとして実行。
-  // root (uid 0)、コンテナの node ユーザー (uid 1000)、または
-  // getuid が利用できない場合（WSL ではないネイティブ Windows）はスキップ。
+  // バインドマウントされたファイルにアクセスできるよう、ホストユーザーとして実行。root (uid 0)、コンテナの node ユーザー (uid 1000)、またはgetuid が利用できない場合（WSL ではないネイティブ Windows）はスキップ。
   const hostUid = process.getuid?.();
   const hostGid = process.getgid?.();
   if (hostUid != null && hostUid !== 0 && hostUid !== 1000) {
@@ -401,8 +395,7 @@ export async function runContainerAgent(
             hadStreamingOutput = true;
             // アクティビティを検出 — ハードタイムアウトをリセット
             resetTimeout();
-            // 「サイレント」なクエリ完了でもアイドルタイマーが開始されるよう、
-            // すべてのマーカー（null 結果を含む）に対して onOutput を呼び出す。
+            // 「サイレント」なクエリ完了でもアイドルタイマーが開始されるよう、すべてのマーカー（null 結果を含む）に対して onOutput を呼び出す。
             outputChain = outputChain.then(() => onOutput(parsed));
           } catch (err) {
             logger.warn(
@@ -420,8 +413,7 @@ export async function runContainerAgent(
       for (const line of lines) {
         if (line) logger.debug({ container: group.folder }, line);
       }
-      // stderr ではタイムアウトをリセットしない — SDK はデバッグログを常に出力するため。
-      // タイムアウトは、実際の出力（stdout 内の OUTPUT_MARKER）に対してのみリセットされる。
+      // stderr ではタイムアウトをリセットしない — SDK はデバッグログを常に出力するため。タイムアウトは、実際の出力（stdout 内の OUTPUT_MARKER）に対してのみリセットされる。
       if (stderrTruncated) return;
       const remaining = CONTAINER_MAX_OUTPUT_SIZE - stderr.length;
       if (chunk.length > remaining) {
@@ -439,8 +431,7 @@ export async function runContainerAgent(
     let timedOut = false;
     let hadStreamingOutput = false;
     const configTimeout = group.containerConfig?.timeout || CONTAINER_TIMEOUT;
-    // 猶予期間: ハード kill が発動する前に、グレースフルな _close センチネルが発動する
-    // 時間を確保するため、ハードタイムアウトは少なくとも IDLE_TIMEOUT + 30秒である必要があります。
+    // 猶予期間: ハード kill が発動する前に、グレースフルな _close センチネルが発動する時間を確保するため、ハードタイムアウトは少なくとも IDLE_TIMEOUT + 30秒である必要があります。
     const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
 
     const killOnTimeout = () => {
@@ -489,8 +480,7 @@ export async function runContainerAgent(
         );
 
         // 出力後のタイムアウト = 失敗ではなく、アイドルのクリーンアップ。
-        // エージェントはすでに応答を送信済み。これはアイドル期間が経過した後に
-        // コンテナが回収されただけである。
+        // エージェントはすでに応答を送信済み。これはアイドル期間が経過した後にコンテナが回収されただけである。
         if (hadStreamingOutput) {
           logger.info(
             { group: group.name, containerName, duration, code },

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -706,14 +706,13 @@ export interface AvailableGroup {
 
 /**
  * コンテナが読み取るための利用可能なグループのスナップショットを書き込みます。
- * メイングループのみが、すべての利用可能なグループを表示できます（アクティブ化のため）。
- * メイン以外のグループは、自身の登録ステータスのみを表示できます。
+ * 特権グループ（main/override）のみが全グループを表示できます。
+ * 非特権グループにはこのファイルは空リストとして書き込まれます。
  */
 export function writeGroupsSnapshot(
   groupFolder: string,
   isPrivileged: boolean,
   groups: AvailableGroup[],
-  registeredJids: Set<string>,
 ): void {
   const groupIpcDir = resolveGroupIpcPath(groupFolder);
   fs.mkdirSync(groupIpcDir, { recursive: true });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -164,12 +164,23 @@ function buildVolumeMounts(
     !Array.isArray(settingsContent.env)
       ? (settingsContent.env as Record<string, unknown>)
       : {};
-  const sanitizedExistingEnv: Record<string, string> = Object.fromEntries(
-    Object.entries(existingEnv).filter(
-      (e): e is [string, string] => typeof e[1] === 'string',
-    ),
-  );
-  settingsContent.env = { ...defaultSettingsEnv, ...sanitizedExistingEnv };
+  const dangerousEnvKeys = new Set(['__proto__', 'constructor', 'prototype']);
+  const sanitizedExistingEnv = Object.create(null) as Record<string, string>;
+  for (const [key, value] of Object.entries(existingEnv)) {
+    if (typeof value === 'string' && !dangerousEnvKeys.has(key)) {
+      sanitizedExistingEnv[key] = value;
+    }
+  }
+  const mergedEnv = Object.create(null) as Record<string, string>;
+  for (const [key, value] of Object.entries(defaultSettingsEnv)) {
+    if (!dangerousEnvKeys.has(key)) {
+      mergedEnv[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(sanitizedExistingEnv)) {
+    mergedEnv[key] = value;
+  }
+  settingsContent.env = mergedEnv;
   // permissions を groupType に基づいて常に同期する
   // （既存環境のアップグレードや groupType 変更時も反映されるようにするため）
   const allowedTools = getDefaultAllowedTools(groupType);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -182,7 +182,7 @@ function buildVolumeMounts(
     JSON.stringify(settingsContent, null, 2) + '\n',
   );
 
-  // container/skills/ から各グループ의 .claude/skills/ にスキルを同期
+  // container/skills/ から各グループの .claude/skills/ にスキルを同期
   const skillsSrc = path.join(process.cwd(), 'container', 'skills');
   const skillsDst = path.join(groupSessionsDir, 'skills');
   if (fs.existsSync(skillsSrc)) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -148,8 +148,11 @@ function buildVolumeMounts(
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         settingsContent = parsed as Record<string, unknown>;
       }
-    } catch {
-      // パース失敗時は空オブジェクトから始める（既存 env は失われるが壊れたファイルより安全）
+    } catch (err) {
+      logger.warn(
+        { group: group.folder, settingsFile, error: err },
+        'Failed to parse settings.json; starting from empty object (existing user settings lost)',
+      );
     }
   }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -717,7 +717,7 @@ export function writeGroupsSnapshot(
   const groupIpcDir = resolveGroupIpcPath(groupFolder);
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
-  // メイングループはすべてのグループを表示でき、他は何も表示できない（グループをアクティブ化できないため）
+  // 特権グループ（main/override）はすべてのグループを表示でき、他は何も表示できない（グループをアクティブ化できないため）
   const visibleGroups = isPrivileged ? groups : [];
 
   const groupsFile = path.join(groupIpcDir, 'available_groups.json');

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -449,26 +449,26 @@ describe('message query LIMIT', () => {
   });
 });
 
-// --- RegisteredGroup isMain round-trip ---
+// --- RegisteredGroup GroupType round-trip ---
 
-describe('registered group isMain', () => {
-  it('persists isMain=true through set/get round-trip', () => {
+describe('registered group type', () => {
+  it('persists type=main through set/get round-trip', () => {
     setRegisteredGroup('main@s.whatsapp.net', {
       name: 'Main Chat',
       folder: 'whatsapp_main',
       trigger: '@Andy',
       added_at: '2024-01-01T00:00:00.000Z',
-      isMain: true,
+      type: 'main',
     });
 
     const groups = getAllRegisteredGroups();
     const group = groups['main@s.whatsapp.net'];
     expect(group).toBeDefined();
-    expect(group.isMain).toBe(true);
+    expect(group.type).toBe('main');
     expect(group.folder).toBe('whatsapp_main');
   });
 
-  it('omits isMain for non-main groups', () => {
+  it('defaults to chat type for non-main groups', () => {
     setRegisteredGroup('group@g.us', {
       name: 'Family Chat',
       folder: 'whatsapp_family-chat',
@@ -479,6 +479,23 @@ describe('registered group isMain', () => {
     const groups = getAllRegisteredGroups();
     const group = groups['group@g.us'];
     expect(group).toBeDefined();
-    expect(group.isMain).toBeUndefined();
+    expect(group.type).toBe('chat');
+  });
+
+  it('persists all GroupType values', () => {
+    const types = ['override', 'main', 'chat', 'thread'] as const;
+    for (const t of types) {
+      const jid = `test-${t}@g.us`;
+      const folder = `whatsapp_test-${t}`;
+      setRegisteredGroup(jid, {
+        name: `Test ${t}`,
+        folder,
+        trigger: '@Andy',
+        added_at: '2024-01-01T00:00:00.000Z',
+        type: t,
+      });
+      const groups = getAllRegisteredGroups();
+      expect(groups[jid].type).toBe(t);
+    }
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -27,7 +27,10 @@ function parseGroupType(
     return groupType as GroupType;
   }
   // 不正な文字列は is_main を無視して 'chat' にフォールバック
-  logger.warn({ groupType }, 'Invalid group_type in DB; falling back to "chat".');
+  logger.warn(
+    { groupType },
+    'Invalid group_type in DB; falling back to "chat".',
+  );
   return 'chat';
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -611,6 +611,9 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   if (!isValidGroupFolder(group.folder)) {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
+  // NOTE: group.type の不正値バリデーションは意図的に省略。
+  // 呼び出し元は TypeScript の GroupType で型付けされているため実質不正値は混入しない。
+  // 個人プロジェクトのため防御的バリデーションは過剰と判断。
   const groupType =
     group.type ?? ((group as { isMain?: boolean }).isMain ? 'main' : 'chat');
   db.prepare(

--- a/src/db.ts
+++ b/src/db.ts
@@ -18,6 +18,7 @@ import {
 function parseGroupType(
   groupType: string | null,
   isMain: number | null,
+  jid?: string,
 ): GroupType {
   if (groupType == null) {
     // NULL はレガシー DB → is_main フォールバック
@@ -28,7 +29,7 @@ function parseGroupType(
   }
   // 不正な文字列は is_main を無視して 'chat' にフォールバック
   logger.warn(
-    { groupType },
+    { jid, groupType },
     'Invalid group_type in DB; falling back to "chat".',
   );
   return 'chat';
@@ -599,7 +600,7 @@ export function getRegisteredGroup(
     );
     return undefined;
   }
-  const groupType = parseGroupType(row.group_type, row.is_main);
+  const groupType = parseGroupType(row.group_type, row.is_main, row.jid);
   return {
     jid: row.jid,
     name: row.name,
@@ -666,7 +667,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       );
       continue;
     }
-    const groupType = parseGroupType(row.group_type, row.is_main);
+    const groupType = parseGroupType(row.group_type, row.is_main, row.jid);
     result[row.jid] = {
       name: row.name,
       folder: row.folder,

--- a/src/db.ts
+++ b/src/db.ts
@@ -615,8 +615,9 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.type ?? ((group as { isMain?: boolean }).isMain ? 'main' : 'chat');
   // JSON 移行や外部入力経由で不正値が混入する可能性があるため、書き込み前に検証する
   if (!VALID_GROUP_TYPES.has(rawType)) {
-    console.warn(
-      `[db] Invalid group.type "${String(rawType)}" for JID ${jid}; falling back to "chat".`,
+    logger.warn(
+      { jid, rawType },
+      'Invalid group.type; falling back to "chat".',
     );
   }
   const groupType = VALID_GROUP_TYPES.has(rawType) ? rawType : 'chat';

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
+import { VALID_GROUP_TYPES } from './group-type.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
@@ -12,13 +13,6 @@ import {
   ScheduledTask,
   TaskRunLog,
 } from './types.js';
-
-const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
-  'override',
-  'main',
-  'chat',
-  'thread',
-]);
 
 /** DB の group_type / is_main から GroupType を解決する */
 function parseGroupType(

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,11 +6,31 @@ import { ASSISTANT_NAME, DATA_DIR, STORE_DIR } from './config.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
+  GroupType,
   NewMessage,
   RegisteredGroup,
   ScheduledTask,
   TaskRunLog,
 } from './types.js';
+
+const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
+  'override',
+  'main',
+  'chat',
+  'thread',
+]);
+
+/** DB の group_type / is_main から GroupType を解決する */
+function parseGroupType(
+  groupType: string | null,
+  isMain: number | null,
+): GroupType {
+  if (groupType && VALID_GROUP_TYPES.has(groupType)) {
+    return groupType as GroupType;
+  }
+  // group_type が NULL や不明な値の場合、is_main からフォールバック
+  return isMain === 1 ? 'main' : 'chat';
+}
 
 let db: Database.Database;
 
@@ -114,6 +134,18 @@ function createSchema(database: Database.Database): void {
     // 過去分への適用: folder = 'main' の既存行をメイングループとしてマーク
     database.exec(
       `UPDATE registered_groups SET is_main = 1 WHERE folder = 'main'`,
+    );
+  } catch {
+    /* カラムはすでに存在します */
+  }
+
+  // group_type カラムが存在しない場合は追加（isMain → GroupType マイグレーション）
+  try {
+    database.exec(
+      `ALTER TABLE registered_groups ADD COLUMN group_type TEXT DEFAULT 'chat'`,
+    );
+    database.exec(
+      `UPDATE registered_groups SET group_type = 'main' WHERE is_main = 1`,
     );
   } catch {
     /* カラムはすでに存在します */
@@ -554,6 +586,7 @@ export function getRegisteredGroup(
         container_config: string | null;
         requires_trigger: number | null;
         is_main: number | null;
+        group_type: string | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -564,6 +597,7 @@ export function getRegisteredGroup(
     );
     return undefined;
   }
+  const groupType = parseGroupType(row.group_type, row.is_main);
   return {
     jid: row.jid,
     name: row.name,
@@ -575,7 +609,7 @@ export function getRegisteredGroup(
       : undefined,
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-    isMain: row.is_main === 1 ? true : undefined,
+    type: groupType,
   };
 }
 
@@ -583,9 +617,10 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   if (!isValidGroupFolder(group.folder)) {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
+  const groupType = group.type ?? 'chat';
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -594,7 +629,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.added_at,
     group.containerConfig ? JSON.stringify(group.containerConfig) : null,
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
-    group.isMain ? 1 : 0,
+    groupType === 'main' || groupType === 'override' ? 1 : 0,
+    groupType,
   );
 }
 
@@ -608,6 +644,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     container_config: string | null;
     requires_trigger: number | null;
     is_main: number | null;
+    group_type: string | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -618,6 +655,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       );
       continue;
     }
+    const groupType = parseGroupType(row.group_type, row.is_main);
     result[row.jid] = {
       name: row.name,
       folder: row.folder,
@@ -628,7 +666,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
         : undefined,
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-      isMain: row.is_main === 1 ? true : undefined,
+      type: groupType,
     };
   }
   return result;

--- a/src/db.ts
+++ b/src/db.ts
@@ -611,7 +611,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   if (!isValidGroupFolder(group.folder)) {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
-  const groupType = group.type ?? 'chat';
+  const groupType =
+    group.type ?? ((group as { isMain?: boolean }).isMain ? 'main' : 'chat');
   db.prepare(
     `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/src/db.ts
+++ b/src/db.ts
@@ -611,11 +611,15 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   if (!isValidGroupFolder(group.folder)) {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
-  // NOTE: group.type の不正値バリデーションは意図的に省略。
-  // 呼び出し元は TypeScript の GroupType で型付けされているため実質不正値は混入しない。
-  // 個人プロジェクトのため防御的バリデーションは過剰と判断。
-  const groupType =
+  const rawType =
     group.type ?? ((group as { isMain?: boolean }).isMain ? 'main' : 'chat');
+  // JSON 移行や外部入力経由で不正値が混入する可能性があるため、書き込み前に検証する
+  if (!VALID_GROUP_TYPES.has(rawType)) {
+    console.warn(
+      `[db] Invalid group.type "${String(rawType)}" for JID ${jid}; falling back to "chat".`,
+    );
+  }
+  const groupType = VALID_GROUP_TYPES.has(rawType) ? rawType : 'chat';
   db.prepare(
     `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/src/db.ts
+++ b/src/db.ts
@@ -19,11 +19,16 @@ function parseGroupType(
   groupType: string | null,
   isMain: number | null,
 ): GroupType {
-  if (groupType && VALID_GROUP_TYPES.has(groupType)) {
+  if (groupType == null) {
+    // NULL はレガシー DB → is_main フォールバック
+    return isMain === 1 ? 'main' : 'chat';
+  }
+  if (VALID_GROUP_TYPES.has(groupType)) {
     return groupType as GroupType;
   }
-  // group_type が NULL や不明な値の場合、is_main からフォールバック
-  return isMain === 1 ? 'main' : 'chat';
+  // 不正な文字列は is_main を無視して 'chat' にフォールバック
+  logger.warn({ groupType }, 'Invalid group_type in DB; falling back to "chat".');
+  return 'chat';
 }
 
 let db: Database.Database;

--- a/src/db.ts
+++ b/src/db.ts
@@ -620,8 +620,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   if (!isValidGroupFolder(group.folder)) {
     throw new Error(`Invalid group folder "${group.folder}" for JID ${jid}`);
   }
-  const rawType =
-    group.type ?? ((group as { isMain?: boolean }).isMain ? 'main' : 'chat');
+  const rawType = group.type ?? 'chat';
   // JSON 移行や外部入力経由で不正値が混入する可能性があるため、書き込み前に検証する
   if (!VALID_GROUP_TYPES.has(rawType)) {
     logger.warn(

--- a/src/group-type.test.ts
+++ b/src/group-type.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  resolveGroupType,
+  hasPrivilege,
+  getDefaultAllowedTools,
+} from './group-type.js';
+import type { RegisteredGroup } from './types.js';
+
+function makeGroup(type: unknown): RegisteredGroup {
+  return {
+    name: 'test',
+    folder: 'test',
+    trigger: '!',
+    added_at: '2026-01-01T00:00:00.000Z',
+    type: type as RegisteredGroup['type'],
+  };
+}
+
+// --- resolveGroupType ---
+
+describe('resolveGroupType', () => {
+  it('returns valid types as-is', () => {
+    expect(resolveGroupType(makeGroup('main'))).toBe('main');
+    expect(resolveGroupType(makeGroup('override'))).toBe('override');
+    expect(resolveGroupType(makeGroup('chat'))).toBe('chat');
+    expect(resolveGroupType(makeGroup('thread'))).toBe('thread');
+  });
+
+  it('falls back to "chat" when type is undefined/null', () => {
+    expect(resolveGroupType(makeGroup(undefined))).toBe('chat');
+    expect(resolveGroupType(makeGroup(null))).toBe('chat');
+  });
+
+  it('falls back to "chat" for unknown/invalid type strings', () => {
+    expect(resolveGroupType(makeGroup('admin'))).toBe('chat');
+    expect(resolveGroupType(makeGroup(''))).toBe('chat');
+    expect(resolveGroupType(makeGroup('MAIN'))).toBe('chat');
+  });
+});
+
+// --- hasPrivilege ---
+
+describe('hasPrivilege', () => {
+  it('returns true for main', () => {
+    expect(hasPrivilege(makeGroup('main'))).toBe(true);
+  });
+
+  it('returns true for override', () => {
+    expect(hasPrivilege(makeGroup('override'))).toBe(true);
+  });
+
+  it('returns false for chat', () => {
+    expect(hasPrivilege(makeGroup('chat'))).toBe(false);
+  });
+
+  it('returns false for thread', () => {
+    expect(hasPrivilege(makeGroup('thread'))).toBe(false);
+  });
+
+  it('returns false for undefined type (falls back to chat)', () => {
+    expect(hasPrivilege(makeGroup(undefined))).toBe(false);
+  });
+
+  it('returns false for invalid type string (falls back to chat)', () => {
+    expect(hasPrivilege(makeGroup('superadmin'))).toBe(false);
+  });
+});
+
+// --- getDefaultAllowedTools ---
+
+describe('getDefaultAllowedTools', () => {
+  it('returns undefined (unrestricted) for main', () => {
+    expect(getDefaultAllowedTools('main')).toBeUndefined();
+  });
+
+  it('returns undefined (unrestricted) for override', () => {
+    expect(getDefaultAllowedTools('override')).toBeUndefined();
+  });
+
+  it('returns ["Read"] for chat', () => {
+    expect(getDefaultAllowedTools('chat')).toEqual(['Read']);
+  });
+
+  it('returns ["Read"] for thread', () => {
+    expect(getDefaultAllowedTools('thread')).toEqual(['Read']);
+  });
+});

--- a/src/group-type.ts
+++ b/src/group-type.ts
@@ -1,5 +1,12 @@
 import type { GroupType, RegisteredGroup } from './types.js';
 
+export const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
+  'override',
+  'main',
+  'chat',
+  'thread',
+]);
+
 /** グループの type を解決する。未指定時は 'chat' */
 export function resolveGroupType(group: RegisteredGroup): GroupType {
   return group.type ?? 'chat';

--- a/src/group-type.ts
+++ b/src/group-type.ts
@@ -1,0 +1,24 @@
+import type { GroupType, RegisteredGroup } from './types.js';
+
+/** グループの type を解決する。未指定時は 'chat' */
+export function resolveGroupType(group: RegisteredGroup): GroupType {
+  return group.type ?? 'chat';
+}
+
+/** main または override の特権を持つかどうか */
+export function hasPrivilege(group: RegisteredGroup): boolean {
+  const t = resolveGroupType(group);
+  return t === 'main' || t === 'override';
+}
+
+/** type ごとのデフォルト allowedTools。undefined は制限なし（全許可） */
+export function getDefaultAllowedTools(type: GroupType): string[] | undefined {
+  switch (type) {
+    case 'override':
+    case 'main':
+      return undefined; // 制限なし
+    case 'chat':
+    case 'thread':
+      return ['Read'];
+  }
+}

--- a/src/group-type.ts
+++ b/src/group-type.ts
@@ -7,9 +7,15 @@ export const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
   'thread',
 ]);
 
-/** グループの type を解決する。未指定時は 'chat' */
+/** グループの type を解決する。未指定時や不正値は 'chat' にフォールバック */
 export function resolveGroupType(group: RegisteredGroup): GroupType {
-  return group.type ?? 'chat';
+  const type = group.type;
+  if (type == null) return 'chat';
+  if (VALID_GROUP_TYPES.has(type)) return type as GroupType;
+  console.warn(
+    `[group-type] Invalid group.type "${String(type)}"; falling back to "chat".`,
+  );
+  return 'chat';
 }
 
 /** main または override の特権を持つかどうか */
@@ -26,6 +32,9 @@ export function getDefaultAllowedTools(type: GroupType): string[] | undefined {
       return undefined; // 制限なし
     case 'chat':
     case 'thread':
+      return ['Read'];
+    default:
+      // 将来 GroupType に新しい値が追加されてもフォールバックで安全側に倒す
       return ['Read'];
   }
 }

--- a/src/group-type.ts
+++ b/src/group-type.ts
@@ -1,3 +1,4 @@
+import { logger } from './logger.js';
 import type { GroupType, RegisteredGroup } from './types.js';
 
 export const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
@@ -12,9 +13,7 @@ export function resolveGroupType(group: RegisteredGroup): GroupType {
   const type = group.type;
   if (type == null) return 'chat';
   if (VALID_GROUP_TYPES.has(type)) return type as GroupType;
-  console.warn(
-    `[group-type] Invalid group.type "${String(type)}"; falling back to "chat".`,
-  );
+  logger.warn({ type }, 'Invalid group.type; falling back to "chat".');
   return 'chat';
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     return true;
   }
 
-  const isMainGroup = hasPrivilege(group);
+  const isPrivileged = hasPrivilege(group);
 
   const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
   const missedMessages = getMessagesSince(
@@ -171,7 +171,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   if (missedMessages.length === 0) return true;
 
   // メイン以外のグループについては、トリガーが必要かつ存在するか確認
-  if (!isMainGroup && group.requiresTrigger !== false) {
+  if (!isPrivileged && group.requiresTrigger !== false) {
     const allowlistCfg = loadSenderAllowlist();
     const hasTrigger = missedMessages.some(
       (m) =>
@@ -394,8 +394,8 @@ async function startMessageLoop(): Promise<void> {
             continue;
           }
 
-          const isMainGroup = hasPrivilege(group);
-          const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
+          const isPrivileged = hasPrivilege(group);
+          const needsTrigger = !isPrivileged && group.requiresTrigger !== false;
 
           // メイン以外のグループについては、トリガーメッセージに対してのみアクションを実行。
           // トリガー以外のメッセージは DB に蓄積され、最終的にトリガーが届いたときに

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import {
   shouldDropMessage,
 } from './sender-allowlist.js';
 import { startSchedulerLoop } from './task-scheduler.js';
+import { hasPrivilege, resolveGroupType } from './group-type.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
 
@@ -158,7 +159,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     return true;
   }
 
-  const isMainGroup = group.isMain === true;
+  const isMainGroup = hasPrivilege(group);
 
   const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
   const missedMessages = getMessagesSince(
@@ -271,7 +272,7 @@ async function runAgent(
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
-  const isMain = group.isMain === true;
+  const isMain = hasPrivilege(group);
   const sessionId = sessions[group.folder];
 
   // コンテナが読み取るためのタスクスナップショットを更新（グループでフィルタリング）
@@ -319,6 +320,7 @@ async function runAgent(
         groupFolder: group.folder,
         chatJid,
         isMain,
+        groupType: resolveGroupType(group),
         assistantName: ASSISTANT_NAME,
       },
       (proc, containerName) =>
@@ -392,7 +394,7 @@ async function startMessageLoop(): Promise<void> {
             continue;
           }
 
-          const isMainGroup = group.isMain === true;
+          const isMainGroup = hasPrivilege(group);
           const needsTrigger = !isMainGroup && group.requiresTrigger !== false;
 
           // メイン以外のグループについては、トリガーメッセージに対してのみアクションを実行。
@@ -501,10 +503,10 @@ async function main(): Promise<void> {
     msg: NewMessage,
   ): Promise<void> {
     const group = registeredGroups[chatJid];
-    if (!group?.isMain) {
+    if (!group || !hasPrivilege(group)) {
       logger.warn(
         { chatJid, sender: msg.sender },
-        'Remote control rejected: not main group',
+        'Remote control rejected: not privileged group',
       );
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,12 +293,7 @@ async function runAgent(
 
   // 利用可能なグループのスナップショットを更新（メイングループのみが全グループを表示可能）
   const availableGroups = getAvailableGroups();
-  writeGroupsSnapshot(
-    group.folder,
-    isPrivileged,
-    availableGroups,
-    new Set(Object.keys(registeredGroups)),
-  );
+  writeGroupsSnapshot(group.folder, isPrivileged, availableGroups);
 
   // ストリームされた結果からセッション ID を追跡するために onOutput をラップ
   const wrappedOnOutput = onOutput
@@ -631,8 +626,7 @@ async function main(): Promise<void> {
       );
     },
     getAvailableGroups,
-    writeGroupsSnapshot: (gf, im, ag, rj) =>
-      writeGroupsSnapshot(gf, im, ag, rj),
+    writeGroupsSnapshot: (gf, im, ag) => writeGroupsSnapshot(gf, im, ag),
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,7 +291,7 @@ async function runAgent(
     })),
   );
 
-  // 利用可能なグループのスナップショットを更新（メイングループのみが全グループを表示可能）
+  // 利用可能なグループのスナップショットを更新（特権グループのみが全グループを表示可能）
   const availableGroups = getAvailableGroups();
   writeGroupsSnapshot(group.folder, isPrivileged, availableGroups);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,7 +272,8 @@ async function runAgent(
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
-  const isPrivileged = hasPrivilege(group);
+  const groupType = resolveGroupType(group);
+  const isPrivileged = groupType === 'main' || groupType === 'override';
   const sessionId = sessions[group.folder];
 
   // コンテナが読み取るためのタスクスナップショットを更新（グループでフィルタリング）
@@ -314,7 +315,7 @@ async function runAgent(
         sessionId,
         groupFolder: group.folder,
         chatJid,
-        groupType: resolveGroupType(group),
+        groupType,
         assistantName: ASSISTANT_NAME,
       },
       (proc, containerName) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   if (missedMessages.length === 0) return true;
 
-  // メイン以外のグループについては、トリガーが必要かつ存在するか確認
+  // 非特権グループ（chat/thread）については、トリガーが必要かつ存在するか確認
   if (!isPrivileged && group.requiresTrigger !== false) {
     const allowlistCfg = loadSenderAllowlist();
     const hasTrigger = missedMessages.some(

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,14 +272,14 @@ async function runAgent(
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
-  const isMain = hasPrivilege(group);
+  const isPrivileged = hasPrivilege(group);
   const sessionId = sessions[group.folder];
 
   // コンテナが読み取るためのタスクスナップショットを更新（グループでフィルタリング）
   const tasks = getAllTasks();
   writeTasksSnapshot(
     group.folder,
-    isMain,
+    isPrivileged,
     tasks.map((t) => ({
       id: t.id,
       groupFolder: t.group_folder,
@@ -295,7 +295,7 @@ async function runAgent(
   const availableGroups = getAvailableGroups();
   writeGroupsSnapshot(
     group.folder,
-    isMain,
+    isPrivileged,
     availableGroups,
     new Set(Object.keys(registeredGroups)),
   );
@@ -319,7 +319,6 @@ async function runAgent(
         sessionId,
         groupFolder: group.folder,
         chatJid,
-        isMain,
         groupType: resolveGroupType(group),
         assistantName: ASSISTANT_NAME,
       },

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   _initTestDatabase,
   createTask,
+  getAllRegisteredGroups,
   getAllTasks,
   getRegisteredGroup,
   getTaskById,
@@ -17,7 +18,7 @@ const MAIN_GROUP: RegisteredGroup = {
   folder: 'whatsapp_main',
   trigger: 'always',
   added_at: '2024-01-01T00:00:00.000Z',
-  isMain: true,
+  type: 'main',
 };
 
 const OTHER_GROUP: RegisteredGroup = {
@@ -674,5 +675,160 @@ describe('register_group success', () => {
     );
 
     expect(getRegisteredGroup('partial@g.us')).toBeUndefined();
+  });
+});
+
+// --- register_group / update_group の group_type 処理 ---
+
+describe('register_group group_type', () => {
+  it('group_type を指定するとその値が DB に反映される', async () => {
+    // メイングループから group_type: 'chat' を指定して登録
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'typed@g.us',
+        name: 'Typed Group',
+        folder: 'typed-group',
+        trigger: '@Andy',
+        group_type: 'chat',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // DB から取得して group_type が正しいか確認
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['typed@g.us']).toBeDefined();
+    expect(allGroups['typed@g.us'].type).toBe('chat');
+  });
+
+  it('group_type: override を指定すると拒否される', async () => {
+    // メイングループから group_type: 'override' を指定して登録を試みる
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'override@g.us',
+        name: 'Override Group',
+        folder: 'override-group',
+        trigger: '@Andy',
+        group_type: 'override',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // override は IPC 経由で設定できないため登録されていないことを確認
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['override@g.us']).toBeUndefined();
+  });
+});
+
+describe('update_group group_type', () => {
+  it('update_group で既存グループの type を変更できる', async () => {
+    // まず type: 'chat' でグループを登録
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'target@g.us',
+        name: 'Target Group',
+        folder: 'target-group',
+        trigger: '@Andy',
+        group_type: 'chat',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+    {
+      const allGroups = getAllRegisteredGroups();
+      expect(allGroups['target@g.us']?.type).toBe('chat');
+    }
+
+    // メイングループから update_group で type を 'main' に変更
+    await processTaskIpc(
+      {
+        type: 'update_group',
+        jid: 'target@g.us',
+        group_type: 'main',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // type が 'main' に変更されていることを確認
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['target@g.us']).toBeDefined();
+    expect(allGroups['target@g.us'].type).toBe('main');
+  });
+
+  it('update_group で override への変更が拒否される', async () => {
+    // まず type: 'chat' でグループを登録
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'noraise@g.us',
+        name: 'No Raise Group',
+        folder: 'noraise-group',
+        trigger: '@Andy',
+        group_type: 'chat',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // override への変更を試みる — 拒否されるべき
+    await processTaskIpc(
+      {
+        type: 'update_group',
+        jid: 'noraise@g.us',
+        group_type: 'override',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // type が 'override' に変わっていないことを確認
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['noraise@g.us']).toBeDefined();
+    expect(allGroups['noraise@g.us'].type).not.toBe('override');
+  });
+
+  it('メイン以外のグループから update_group は拒否される', async () => {
+    // まず type: 'chat' でグループを登録
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'protected@g.us',
+        name: 'Protected Group',
+        folder: 'protected-group',
+        trigger: '@Andy',
+        group_type: 'chat',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    // メイン以外のグループ（other-group）から update_group を発行 — 拒否されるべき
+    await processTaskIpc(
+      {
+        type: 'update_group',
+        jid: 'protected@g.us',
+        group_type: 'main',
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    // type が変わっていないことを確認
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['protected@g.us']).toBeDefined();
+    expect(allGroups['protected@g.us'].type).toBe('chat');
   });
 });

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -7,8 +7,23 @@ import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
+import { hasPrivilege } from './group-type.js';
 import { logger } from './logger.js';
-import { RegisteredGroup } from './types.js';
+import { GroupType, RegisteredGroup } from './types.js';
+
+const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
+  'override',
+  'main',
+  'chat',
+  'thread',
+]);
+
+function parseIpcGroupType(value: unknown): GroupType | null {
+  if (typeof value === 'string' && VALID_GROUP_TYPES.has(value)) {
+    return value as GroupType;
+  }
+  return null;
+}
 
 export interface IpcDeps {
   sendMessage: (jid: string, text: string) => Promise<void>;
@@ -18,7 +33,7 @@ export interface IpcDeps {
   getAvailableGroups: () => AvailableGroup[];
   writeGroupsSnapshot: (
     groupFolder: string,
-    isMain: boolean,
+    isPrivileged: boolean,
     availableGroups: AvailableGroup[],
     registeredJids: Set<string>,
   ) => void;
@@ -52,14 +67,14 @@ export function startIpcWatcher(deps: IpcDeps): void {
 
     const registeredGroups = deps.registeredGroups();
 
-    // 登録済みグループから folder→isMain のルックアップを構築
-    const folderIsMain = new Map<string, boolean>();
+    // 登録済みグループから folder→hasPrivilege のルックアップを構築
+    const folderPrivilege = new Map<string, boolean>();
     for (const group of Object.values(registeredGroups)) {
-      if (group.isMain) folderIsMain.set(group.folder, true);
+      if (hasPrivilege(group)) folderPrivilege.set(group.folder, true);
     }
 
     for (const sourceGroup of groupFolders) {
-      const isMain = folderIsMain.get(sourceGroup) === true;
+      const isPrivileged = folderPrivilege.get(sourceGroup) === true;
       const messagesDir = path.join(ipcBaseDir, sourceGroup, 'messages');
       const tasksDir = path.join(ipcBaseDir, sourceGroup, 'tasks');
 
@@ -77,7 +92,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
                 // 認可: このグループが対象の chatJid に送信可能か確認
                 const targetGroup = registeredGroups[data.chatJid];
                 if (
-                  isMain ||
+                  isPrivileged ||
                   (targetGroup && targetGroup.folder === sourceGroup)
                 ) {
                   await deps.sendMessage(data.chatJid, data.text);
@@ -125,7 +140,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               // 認可のため送信元グループの識別情報を processTaskIpc に渡す
-              await processTaskIpc(data, sourceGroup, isMain, deps);
+              await processTaskIpc(data, sourceGroup, isPrivileged, deps);
               fs.unlinkSync(filePath);
             } catch (err) {
               logger.error(
@@ -164,16 +179,17 @@ export async function processTaskIpc(
     groupFolder?: string;
     chatJid?: string;
     targetJid?: string;
-    // register_group 用
+    // register_group / update_group 用
     jid?: string;
     name?: string;
     folder?: string;
     trigger?: string;
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
+    group_type?: string;
   },
   sourceGroup: string, // IPC ディレクトリから検証された識別情報
-  isMain: boolean, // ディレクトリパスから検証された情報
+  isPrivileged: boolean, // main または override の特権を持つか
   deps: IpcDeps,
 ): Promise<void> {
   const registeredGroups = deps.registeredGroups();
@@ -201,7 +217,7 @@ export async function processTaskIpc(
         const targetFolder = targetGroupEntry.folder;
 
         // 認可: メイン以外のグループは自分自身に対してのみスケジュール可能
-        if (!isMain && targetFolder !== sourceGroup) {
+        if (!isPrivileged && targetFolder !== sourceGroup) {
           logger.warn(
             { sourceGroup, targetFolder },
             'Unauthorized schedule_task attempt blocked',
@@ -276,7 +292,7 @@ export async function processTaskIpc(
     case 'pause_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
+        if (task && (isPrivileged || task.group_folder === sourceGroup)) {
           updateTask(data.taskId, { status: 'paused' });
           logger.info(
             { taskId: data.taskId, sourceGroup },
@@ -294,7 +310,7 @@ export async function processTaskIpc(
     case 'resume_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
+        if (task && (isPrivileged || task.group_folder === sourceGroup)) {
           updateTask(data.taskId, { status: 'active' });
           logger.info(
             { taskId: data.taskId, sourceGroup },
@@ -312,7 +328,7 @@ export async function processTaskIpc(
     case 'cancel_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
+        if (task && (isPrivileged || task.group_folder === sourceGroup)) {
           deleteTask(data.taskId);
           logger.info(
             { taskId: data.taskId, sourceGroup },
@@ -337,7 +353,7 @@ export async function processTaskIpc(
           );
           break;
         }
-        if (!isMain && task.group_folder !== sourceGroup) {
+        if (!isPrivileged && task.group_folder !== sourceGroup) {
           logger.warn(
             { taskId: data.taskId, sourceGroup },
             'Unauthorized task update attempt',
@@ -393,7 +409,7 @@ export async function processTaskIpc(
 
     case 'refresh_groups':
       // メイングループのみがリフレッシュを要求可能
-      if (isMain) {
+      if (isPrivileged) {
         logger.info(
           { sourceGroup },
           'Group metadata refresh requested via IPC',
@@ -417,7 +433,7 @@ export async function processTaskIpc(
 
     case 'register_group':
       // メイングループのみが新しいグループを登録可能
-      if (!isMain) {
+      if (!isPrivileged) {
         logger.warn(
           { sourceGroup },
           'Unauthorized register_group attempt blocked',
@@ -432,7 +448,15 @@ export async function processTaskIpc(
           );
           break;
         }
-        // 多層防御: エージェントは IPC 経由で isMain を設定できない
+        // 多層防御: エージェントは IPC 経由で override を設定できない
+        if (data.group_type === 'override') {
+          logger.warn(
+            { sourceGroup },
+            'override type cannot be set via IPC',
+          );
+          break;
+        }
+        const groupType = parseIpcGroupType(data.group_type) ?? 'chat';
         deps.registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
@@ -440,11 +464,66 @@ export async function processTaskIpc(
           added_at: new Date().toISOString(),
           containerConfig: data.containerConfig,
           requiresTrigger: data.requiresTrigger,
+          type: groupType,
         });
+        logger.info(
+          { jid: data.jid, folder: data.folder, groupType, sourceGroup },
+          'Group registered via IPC',
+        );
       } else {
         logger.warn(
           { data },
           'Invalid register_group request - missing required fields',
+        );
+      }
+      break;
+
+    case 'update_group':
+      // メイン/override グループのみが既存グループの設定を変更可能
+      if (!isPrivileged) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized update_group attempt blocked',
+        );
+        break;
+      }
+      // override への変更は IPC 経由で不可
+      if (data.group_type === 'override') {
+        logger.warn(
+          { sourceGroup },
+          'override type cannot be set via IPC',
+        );
+        break;
+      }
+      if (data.jid && data.group_type) {
+        const newType = parseIpcGroupType(data.group_type);
+        if (!newType) {
+          logger.warn(
+            { sourceGroup, group_type: data.group_type },
+            'Invalid group_type in update_group request',
+          );
+          break;
+        }
+        const targetGroup = registeredGroups[data.jid];
+        if (!targetGroup) {
+          logger.warn(
+            { sourceGroup, jid: data.jid },
+            'update_group: target group not found',
+          );
+          break;
+        }
+        deps.registerGroup(data.jid, {
+          ...targetGroup,
+          type: newType,
+        });
+        logger.info(
+          { jid: data.jid, newType, sourceGroup },
+          'Group type updated via IPC',
+        );
+      } else {
+        logger.warn(
+          { data },
+          'Invalid update_group request - missing jid or group_type',
         );
       }
       break;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -450,10 +450,7 @@ export async function processTaskIpc(
         }
         // 多層防御: エージェントは IPC 経由で override を設定できない
         if (data.group_type === 'override') {
-          logger.warn(
-            { sourceGroup },
-            'override type cannot be set via IPC',
-          );
+          logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
           break;
         }
         const groupType = parseIpcGroupType(data.group_type) ?? 'chat';
@@ -489,10 +486,7 @@ export async function processTaskIpc(
       }
       // override への変更は IPC 経由で不可
       if (data.group_type === 'override') {
-        logger.warn(
-          { sourceGroup },
-          'override type cannot be set via IPC',
-        );
+        logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
         break;
       }
       if (data.jid && data.group_type) {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -412,7 +412,7 @@ export async function processTaskIpc(
         const availableGroups = deps.getAvailableGroups();
         deps.writeGroupsSnapshot(
           sourceGroup,
-          true,
+          isPrivileged,
           availableGroups,
           new Set(Object.keys(registeredGroups)),
         );

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -28,7 +28,6 @@ export interface IpcDeps {
     groupFolder: string,
     isPrivileged: boolean,
     availableGroups: AvailableGroup[],
-    registeredJids: Set<string>,
   ) => void;
 }
 
@@ -410,12 +409,7 @@ export async function processTaskIpc(
         await deps.syncGroups(true);
         // 更新されたスナップショットを即座に書き出し
         const availableGroups = deps.getAvailableGroups();
-        deps.writeGroupsSnapshot(
-          sourceGroup,
-          isPrivileged,
-          availableGroups,
-          new Set(Object.keys(registeredGroups)),
-        );
+        deps.writeGroupsSnapshot(sourceGroup, isPrivileged, availableGroups);
       } else {
         logger.warn(
           { sourceGroup },

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -7,16 +7,9 @@ import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
-import { hasPrivilege } from './group-type.js';
+import { hasPrivilege, VALID_GROUP_TYPES } from './group-type.js';
 import { logger } from './logger.js';
 import { GroupType, RegisteredGroup } from './types.js';
-
-const VALID_GROUP_TYPES: ReadonlySet<string> = new Set([
-  'override',
-  'main',
-  'chat',
-  'thread',
-]);
 
 function parseIpcGroupType(value: unknown): GroupType | null {
   if (typeof value === 'string' && VALID_GROUP_TYPES.has(value)) {
@@ -432,7 +425,7 @@ export async function processTaskIpc(
       break;
 
     case 'register_group':
-      // メイングループのみが新しいグループを登録可能
+      // main または override グループのみが新しいグループを登録可能
       if (!isPrivileged) {
         logger.warn(
           { sourceGroup },
@@ -453,7 +446,17 @@ export async function processTaskIpc(
           logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
           break;
         }
-        const groupType = parseIpcGroupType(data.group_type) ?? 'chat';
+        const parsedGroupType = data.group_type
+          ? parseIpcGroupType(data.group_type)
+          : null;
+        if (data.group_type && !parsedGroupType) {
+          logger.warn(
+            { sourceGroup, group_type: data.group_type },
+            'Invalid group_type in register_group request',
+          );
+          break;
+        }
+        const groupType = parsedGroupType ?? 'chat';
         deps.registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -401,7 +401,7 @@ export async function processTaskIpc(
       break;
 
     case 'refresh_groups':
-      // メイングループのみがリフレッシュを要求可能
+      // 特権グループ（main/override）のみがリフレッシュを要求可能
       if (isPrivileged) {
         logger.info(
           { sourceGroup },

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -446,10 +446,14 @@ export async function processTaskIpc(
           logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
           break;
         }
-        const parsedGroupType = data.group_type
+        const hasGroupType = Object.prototype.hasOwnProperty.call(
+          data,
+          'group_type',
+        );
+        const parsedGroupType = hasGroupType
           ? parseIpcGroupType(data.group_type)
           : null;
-        if (data.group_type && !parsedGroupType) {
+        if (hasGroupType && !parsedGroupType) {
           logger.warn(
             { sourceGroup, group_type: data.group_type },
             'Invalid group_type in register_group request',

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -208,7 +208,7 @@ export async function processTaskIpc(
 
         const targetFolder = targetGroupEntry.folder;
 
-        // 認可: メイン以外のグループは自分自身に対してのみスケジュール可能
+        // 認可: 特権以外（chat/thread）のグループは自分自身に対してのみスケジュール可能
         if (!isPrivileged && targetFolder !== sourceGroup) {
           logger.warn(
             { sourceGroup, targetFolder },

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -232,7 +232,8 @@ export interface MountValidationResult {
  */
 export function validateMount(
   mount: AdditionalMount,
-  isMain: boolean,
+  isMain: boolean, // true = main または override の特権グループ
+
 ): MountValidationResult {
   const allowlist = loadMountAllowlist();
 
@@ -336,7 +337,8 @@ export function validateMount(
 export function validateAdditionalMounts(
   mounts: AdditionalMount[],
   groupName: string,
-  isMain: boolean,
+  isMain: boolean, // true = main または override の特権グループ
+
 ): Array<{
   hostPath: string;
   containerPath: string;

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -233,7 +233,6 @@ export interface MountValidationResult {
 export function validateMount(
   mount: AdditionalMount,
   isMain: boolean, // true = main または override の特権グループ
-
 ): MountValidationResult {
   const allowlist = loadMountAllowlist();
 
@@ -338,7 +337,6 @@ export function validateAdditionalMounts(
   mounts: AdditionalMount[],
   groupName: string,
   isMain: boolean, // true = main または override の特権グループ
-
 ): Array<{
   hostPath: string;
   containerPath: string;

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -232,7 +232,7 @@ export interface MountValidationResult {
  */
 export function validateMount(
   mount: AdditionalMount,
-  isMain: boolean, // true = main または override の特権グループ
+  isPrivileged: boolean, // true = main または override の特権グループ
 ): MountValidationResult {
   const allowlist = loadMountAllowlist();
 
@@ -294,14 +294,14 @@ export function validateMount(
   let effectiveReadonly = true; // デフォルトは読み取り専用
 
   if (requestedReadWrite) {
-    if (!isMain && allowlist.nonMainReadOnly) {
-      // メイン以外のグループは強制的に読み取り専用
+    if (!isPrivileged && allowlist.nonMainReadOnly) {
+      // 特権のないグループは強制的に読み取り専用
       effectiveReadonly = true;
       logger.info(
         {
           mount: mount.hostPath,
         },
-        'Mount forced to read-only for non-main group',
+        'Mount forced to read-only for non-privileged group',
       );
     } else if (!allowedRoot.allowReadWrite) {
       // ルートが読み書きを許可していない
@@ -336,7 +336,7 @@ export function validateMount(
 export function validateAdditionalMounts(
   mounts: AdditionalMount[],
   groupName: string,
-  isMain: boolean, // true = main または override の特権グループ
+  isPrivileged: boolean, // true = main または override の特権グループ
 ): Array<{
   hostPath: string;
   containerPath: string;
@@ -349,7 +349,7 @@ export function validateAdditionalMounts(
   }> = [];
 
   for (const mount of mounts) {
-    const result = validateMount(mount, isMain);
+    const result = validateMount(mount, isPrivileged);
 
     if (result.allowed) {
       validatedMounts.push({

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -18,6 +18,7 @@ import {
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
+import { hasPrivilege, resolveGroupType } from './group-type.js';
 import { logger } from './logger.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
 
@@ -130,11 +131,11 @@ async function runTask(
   }
 
   // コンテナが読み取るためのタスクスナップショットを更新します（グループでフィルタリング）
-  const isMain = group.isMain === true;
+  const isPrivileged = hasPrivilege(group);
   const tasks = getAllTasks();
   writeTasksSnapshot(
     task.group_folder,
-    isMain,
+    isPrivileged,
     tasks.map((t) => ({
       id: t.id,
       groupFolder: t.group_folder,
@@ -176,7 +177,8 @@ async function runTask(
         sessionId,
         groupFolder: task.group_folder,
         chatJid: task.chat_jid,
-        isMain,
+        isMain: isPrivileged,
+        groupType: resolveGroupType(group),
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,
       },

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -177,7 +177,6 @@ async function runTask(
         sessionId,
         groupFolder: task.group_folder,
         chatJid: task.chat_jid,
-        isMain: isPrivileged,
         groupType: resolveGroupType(group),
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -18,7 +18,7 @@ import {
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
-import { hasPrivilege, resolveGroupType } from './group-type.js';
+import { resolveGroupType } from './group-type.js';
 import { logger } from './logger.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
 
@@ -131,7 +131,8 @@ async function runTask(
   }
 
   // コンテナが読み取るためのタスクスナップショットを更新します（グループでフィルタリング）
-  const isPrivileged = hasPrivilege(group);
+  const groupType = resolveGroupType(group);
+  const isPrivileged = groupType === 'main' || groupType === 'override';
   const tasks = getAllTasks();
   writeTasksSnapshot(
     task.group_folder,
@@ -177,7 +178,7 @@ async function runTask(
         sessionId,
         groupFolder: task.group_folder,
         chatJid: task.chat_jid,
-        groupType: resolveGroupType(group),
+        groupType,
         isScheduledTask: true,
         assistantName: ASSISTANT_NAME,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,9 @@ export type PlaceType =
 /** ユーザーの権限ロール */
 export type ActorRole = 'owner' | 'admin' | 'user';
 
+/** グループの権限タイプ */
+export type GroupType = 'override' | 'main' | 'chat' | 'thread';
+
 export interface RegisteredGroup {
   name: string;
   folder: string;
@@ -54,7 +57,7 @@ export interface RegisteredGroup {
   added_at: string;
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // デフォルト: グループの場合は true、個人チャットの場合は false
-  isMain?: boolean; // メインコントロールグループの場合は true（トリガー不要、特権あり）
+  type?: GroupType; // 未指定時は 'chat' として扱う
   channel_mode?: 'chat' | 'url_watch' | 'admin_control';
   chat_behavior?: 'ambient_room_chat' | 'directed_help_chat';
 }


### PR DESCRIPTION
- [x] Fix error messages and tool descriptions in `container/agent-runner/src/ipc-mcp-stdio.ts` to accurately reflect that both `main` and `override` groups are privileged
- [x] Replace literal `true` with `isPrivileged` in `deps.writeGroupsSnapshot(...)` inside `refresh_groups` branch in `src/ipc.ts`
- [x] Add `jid` context to `parseGroupType` warn log in `src/db.ts` so invalid DB records are traceable
- [x] Add unit tests for `resolveGroupType`, `hasPrivilege`, and `getDefaultAllowedTools` in `src/group-type.test.ts`
- [x] Compute `groupType` once via `resolveGroupType(group)` and derive `isPrivileged` from it in `runAgent` (`src/index.ts`) and `runScheduledTask` (`src/task-scheduler.ts`) to eliminate duplicate `resolveGroupType` calls