### PR TITLE
feat(thread): Discord thread を派生 group として自動登録 + session 分離

### DIFF
--- a/docs/thread-based-architecture/background.md
+++ b/docs/thread-based-architecture/background.md
@@ -78,3 +78,22 @@ VRC-AI-Bot の型体系は NanoClaw のエージェント分離の発展形 — 
 ### 方針転換の経緯
 
 現ブランチで `PlaceType` / `ActorRole` の型定義を VRC-AI-Bot から移植したが、検討の結果これらは不要と判断。NanoClaw の既存グループモデルの拡張で、VRC-AI-Bot が型の組み合わせでやっていたことを単一の `GroupType` プロパティとコンテナの物理的分離で表現できる。
+
+## thread の考え方
+
+NanoClaw における `thread` は、VRC-AI-Bot の `public_thread` / `private_thread` / `forum_post_thread` のような **Discord 上の場所の分類** をそのまま移植したものではない。
+
+- `chat`: 永続的な会話窓口
+- `thread`: 親 group から派生する、作業や委任のための会話単位
+
+つまり `thread` は **UI 上の Discord thread というより、NanoClaw の権限・ライフサイクルモデルにおける派生 group** を表す。
+
+Discord thread はその派生 group を表現する自然な UI として使えるが、重要なのは PlaceType の細分化ではなく、以下の 3 点。
+
+- 親 group とは別 JID / 別 session を持つこと
+- 親から必要最小限の設定だけを継承できること
+- `chat` より短命で、タスク単位の作業場所として扱えること
+
+`folder` まで分けると管理コストが急増して収拾がつかなくなるため、`thread` の分離はまず **JID と Claude session** に限定する。将来的に設定を変えたくなった場合は、**各 group ごと** に Claude の設定を切り替えられるようにする。
+
+このため、VRC-AI-Bot の `Scope` や `ChatBehavior` を戻すのではなく、Discord adapter 側で thread を検知し、`thread_defaults` と group 自動登録で NanoClaw のモデルに落とし込むのが正しい寄せ方になる。

--- a/docs/thread-based-architecture/channel-agent-isolation.md
+++ b/docs/thread-based-architecture/channel-agent-isolation.md
@@ -133,39 +133,47 @@ container-runner.ts: buildVolumeMounts()
 
 ## GroupType との関係
 
-`GroupType` は **権限の「レベル」** を決め、`agent` は **権限の「種類」** を決める。
+`GroupType` は **権限の「レベル」** を決め、将来の共有設定は **通常 group と thread 群で何を有効にするか** を決める。
 
 ```
 GroupType (垂直方向: 何ができるか)
   override ──── サンドボックスなし、フル権限
   main ──────── Bash、ファイル操作、cron
   chat ──────── 返信のみ（デフォルト）
-  thread ────── 制限付きタスク実行
+  thread ────── 派生した作業単位
 
-agent (水平方向: 何にアクセスできるか)
+shared config (水平方向: 何を有効にするか)
   メール専用 ── Gmail MCP のみ
   RSS 専用 ─── Fetch MCP のみ
   汎用 ──────── 全ツール
 ```
 
-GroupType が `chat` でも `agent` で MCP を付与すれば、「返信しかしないがメール操作はできる」エージェントが作れる。
+GroupType が `chat` でも、将来の共有設定で MCP を付与すれば、「返信しかしないがメール操作はできる」group が作れる。
 
 ## thread_defaults との統合
 
-親チャネルの `thread_defaults` に `agent` を含めれば、スレッド作成時に自動で同じツール制限が適用される。
+親チャネルの `thread_defaults` に将来の thread 用共有設定を含めれば、スレッド作成時に自動で同じ設定を適用できる。
+
+ここでの `thread_defaults` は、Discord の thread をそのまま設定対象にするための機能ではなく、親 group から派生する NanoClaw の `thread` group に最小限の設定を受け渡すためのもの。
+
+設計上の優先順位は次の通り。
+
+- まず `thread` を独立した group / session として扱う
+- その上で thread 群で共有する設定を継承する
+- VRC-AI-Bot のような `PlaceType` や `Scope` の復活は前提にしない
 
 ```ts
 {
   name: "discord-email",
   type: "chat",
-  agent: {
+  shared_config: {
     mcpServers: { gmail: { ... } },
     allowedTools: ["mcp__gmail__*"],
   },
   thread_defaults: {
     type: "thread",
-    agent: {
-      // 親の agent を継承（明示的にオーバーライド可能）
+    shared_config: {
+      // thread 群で共有する設定を継承
       inherit: true
     }
   }
@@ -174,30 +182,30 @@ GroupType が `chat` でも `agent` で MCP を付与すれば、「返信しか
 
 ## セキュリティ考慮
 
-- `agent.mcpServers` で指定される MCP コマンドは、コンテナ内で実行される（ホストではない）
+- 将来の共有設定で指定される MCP コマンドは、コンテナ内で実行される（ホストではない）
 - 認証情報は引き続き credential-proxy 経由で注入 — MCP サーバーが直接シークレットを持つことはない
 - `allowedTools` は Claude Code の既存のパーミッションシステムに委譲
 - `type: 'chat'` のグループが `agent` で Bash を許可しても、GroupType のサンドボックスポリシーが優先される（将来の実装で強制）
 
 ## 実装に必要なもの
 
-1. **`AgentConfig` 型定義** を `types.ts` に追加
-2. **`container-runner.ts` の settings.json 生成** を agent 対応に拡張
-3. **`container-runner.ts` の skills 同期** を agent.skills で選択的に
-4. **IPC の `register_group` / `update_group` で agent を設定** できるように
-5. **thread_defaults の agent 継承ロジック**
+1. **通常 group 用 / thread 用共有設定の型定義** を `types.ts` に追加
+2. **`container-runner.ts` の settings.json 生成** を共有設定対応に拡張
+3. **`container-runner.ts` の skills 同期** を共有設定ベースで選択的に
+4. **IPC の `register_group` / `update_group` で共有設定を保存** できるように
+5. **thread_defaults の設定継承ロジック**
 
 ## 設定方法: DB + IPC 拡張
 
-`agent` 設定は `containerConfig` と同じパターンで、DB に JSON として保存する。
+通常 group 用 / thread 用共有設定は `containerConfig` と同じパターンで、DB に JSON として保存する。
 
 ### DB スキーマ変更
 
 ```sql
-ALTER TABLE registered_groups ADD COLUMN agent_config TEXT;
+ALTER TABLE registered_groups ADD COLUMN shared_config TEXT;
 ```
 
-`agent_config` には `AgentConfig` の JSON を格納する。NULL の場合は `type` のデフォルト設定を使用（`chat` / `thread` は `allowedTools: ["Read"]`、`main` / `override` は全許可。詳細は [group-type-spec.md](group-type-spec.md#type-ごとのデフォルト-allowedtools) を参照）。
+`shared_config` には共有設定 JSON を格納する。NULL の場合は `type` のデフォルト設定を使用（`chat` / `thread` は `allowedTools: ["Read"]`、`main` / `override` は全許可。詳細は [group-type-spec.md](group-type-spec.md#type-ごとのデフォルト-allowedtools) を参照）。
 
 ### 保存される JSON の例
 
@@ -213,6 +221,8 @@ ALTER TABLE registered_groups ADD COLUMN agent_config TEXT;
   "skills": []
 }
 ```
+
+`thread` のために別 `folder` や独立したパーミッション階層を持たせる必要はない。必要なのは別 JID、別 Claude session、そして将来 thread 群で共有する設定を差し替えられる拡張ポイント。
 
 ### IPC での設定
 

--- a/docs/thread-based-architecture/group-type-spec.md
+++ b/docs/thread-based-architecture/group-type-spec.md
@@ -9,6 +9,12 @@ type GroupType = 'override' | 'main' | 'chat' | 'thread';
 // 指定なし・不明な値 → 'chat' がデフォルト
 ```
 
+## この文書の位置づけ
+
+この文書は `GroupType` の **設計目標** を記述する。実装は段階的に追従しており、特に `thread` については「最終的に目指す姿」と「現状の実装」がまだ一致していない箇所がある。
+
+現状の実装では `thread` は主に非特権グループとして扱われ、権限面では `chat` に近い。`thread` が `chat` と明確に違う意味を持つのは、`thread_defaults` による自動登録、親からの設定継承、別 JID / 別 session を持つ派生 group というライフサイクルが揃ってから。
+
 ## 権限階層
 
 | type | サンドボックス | 権限 | ライフサイクル |
@@ -52,11 +58,13 @@ type GroupType = 'override' | 'main' | 'chat' | 'thread';
 ### `thread` — タスク実行スレッド
 
 - 制限付きコンテナで動作
-- コンテナのマウント設定で物理的にアクセス範囲を制限
 - メインからの委任タスクの実行など
 - スレッド単位で生成・破棄
+- Discord の「場所の型」ではなく、親 group から派生する作業単位として扱う
+- 親 group と別 JID / 別 Claude session を持つ
+- 将来的には通常 group 用設定と thread 用共有設定を切り替えられる前提で設計する
 
-**安全策**: コンテナのマウント設定で物理的にアクセス範囲を制限
+**安全策**: `thread` は `main` / `override` ではない非特権 group として扱い、昇格は親 group や IPC 認可で制御する
 
 ## グループモデルでの表現
 
@@ -76,7 +84,9 @@ type GroupType = 'override' | 'main' | 'chat' | 'thread';
 
 ## スレッド自動登録
 
-親チャネルに `thread_defaults` を設定し、スレッド作成時に `dc:{threadId}` で子グループを自動登録。親の設定を継承しつつ独自の `folder` と `CLAUDE.md` を持つ。
+親チャネルに `thread_defaults` を設定し、スレッド作成時に `dc:{threadId}` で子グループを自動登録する。親の設定を継承しつつ、親とは別の JID と Claude session を持つ。
+
+ここで重要なのは、「Discord 上で thread だから `type: 'thread'`」ではなく、**親 group が `thread_defaults` を持つときに、その thread を NanoClaw の派生 group として採用する**こと。単なる Discord thread の存在自体は、NanoClaw の `thread` を意味しない。
 
 ```ts
 // 親チャネル（テンプレート）
@@ -99,6 +109,18 @@ type GroupType = 'override' | 'main' | 'chat' | 'thread';
 4. **スレッド検知時の自動グループ登録ロジック**: Discord スレッド作成イベントをフックし、親の `thread_defaults` に基づいてグループを自動登録
 5. **スラッシュコマンド**: `/override-start`（オーバーライドスレッド作成）、`/override-end`（終了・アーカイブ）
 
+### 実装順序の推奨
+
+`thread` は段階的に入れる。
+
+1. Discord adapter が thread を正しく検知できるようにする
+2. 親 group の `thread_defaults` に基づいて子 group を自動登録する
+3. 子 group に独立した session を持たせる
+4. 将来的に thread 用共有設定を差し替えられる形にする
+5. 必要なら archive や cleanup をライフサイクルに追加する
+
+この順序なら、VRC-AI-Bot の PlaceType モデルを持ち込まずに、NanoClaw の「group 単位の会話分離と設定分離」という哲学のまま `thread` を成立させられる。
+
 ## 設定方法: DB + IPC 拡張
 
 `type` は既存の `isMain` と同じ方式で DB に保存する。`isMain: boolean` を `type: GroupType` に置き換える形。
@@ -111,7 +133,7 @@ ALTER TABLE registered_groups ADD COLUMN type TEXT DEFAULT 'chat';
 UPDATE registered_groups SET type = 'main' WHERE is_main = 1;
 ```
 
-`isMain` カラムは互換性のため残し、読み込み時に `type` を優先する。将来的に削除。
+`is_main` DB カラムは互換性のため残し、読み込み時に `group_type` を優先する（`parseGroupType` のフォールバック）。TypeScript 側の `isMain` プロパティは削除済み。
 
 ### IPC での設定
 
@@ -127,6 +149,7 @@ UPDATE registered_groups SET type = 'main' WHERE is_main = 1;
   "group_type": "chat"
 }
 ```
+`trigger` はエージェントを起動するメッセージのプレフィックス文字列（例: `"!"` `"@Andy"` `"always"`）で、DB の `trigger_pattern` カラムに対応する。
 
 メインエージェントへの自然言語指示で設定する:
 
@@ -174,6 +197,8 @@ if (data.group_type === 'override') {
 | `main` | 制限なし（全許可） | Bash、ファイル操作等が必要 |
 | `chat` | `["Read"]` | 会話のみ。Read はCLAUDE.md等の読み込みに必要（副作用なし）。追加ツールは `agent_config` で明示的に付与 |
 | `thread` | `["Read"]` | タスクに必要なツールは `agent_config` or `thread_defaults` で付与。Read は最低限残す |
+
+`thread` に `chat` とは別の独立パーミッション階層を持たせることはこの文書の目的ではない。差分はまずライフサイクルと session 分離に置き、必要なツール差分は将来の thread 用共有設定で表現する。
 
 ### override のライフサイクル
 

--- a/docs/thread-based-architecture/thread-implementation-plan.md
+++ b/docs/thread-based-architecture/thread-implementation-plan.md
@@ -79,6 +79,9 @@
 保存:
 - DB に `thread_defaults` 用 JSON カラムを追加する
 - `register_group` / `update_group` IPC で保存できるようにする
+- IPC 受信時に `thread_defaults` の型を検証する（`type`/`requiresTrigger`/`containerConfig`）
+- DB 読み込み時も `container_config` / `thread_defaults` をサニタイズし、不正値は無視して継続する
+- `registered_groups` は `jid` で upsert し、`folder` は UNIQUE 制約を持たない（親と thread で共有可能）
 
 自動登録ルール:
 - thread message を受信したが、その `chat_jid` に対応する登録 group がない場合のみ発火

--- a/docs/thread-based-architecture/thread-implementation-plan.md
+++ b/docs/thread-based-architecture/thread-implementation-plan.md
@@ -85,7 +85,7 @@
 - 親 channel の `chat_jid` を導出し、親 group を探す
 - 親 group に `thread_defaults` がなければ何もしない
 - 親 group に `thread_defaults` があれば、その内容を使って子 group を登録する
-- 子 group の `type` は `thread`
+- 子 group の `type` は `thread_defaults.type ?? 'thread'`（非特権値のみ）
 - 子 group の `jid` は `dc:{threadId}`
 - 子 group の `folder` は親 group と同じ値を使う
   - `thread` は別 folder を持たない

--- a/docs/thread-based-architecture/thread-implementation-plan.md
+++ b/docs/thread-based-architecture/thread-implementation-plan.md
@@ -142,8 +142,13 @@
 `index.ts` のメッセージ処理は次の 2 層で動く。
 
 ```
-onMessage callback (channel → index.ts)
-  └── storeMessage(msg)   ← 登録済みかどうかに関わらず DB に保存
+discord.ts (チャンネルアダプター)
+  └── 未登録チャンネル/スレッド → ドロップ（例外: 親に thread_defaults がある thread は通す）
+        └── onMessage callback (channel → index.ts)
+              ├── 未登録 + parent_jid あり + 親に thread_defaults あり
+              │     → autoRegisterThread() → 登録完了後に storeMessage
+              ├── 未登録 + parent_jid なし／親に thread_defaults なし → return（ドロップ）
+              └── 登録済み → sender-allowlist チェック → storeMessage
 
 startMessageLoop (POLL_INTERVAL ごと)
   └── getNewMessages(registered jids only)
@@ -152,37 +157,35 @@ startMessageLoop (POLL_INTERVAL ごと)
                     └── processGroupMessages → runAgent
 ```
 
-重要な点として、`onMessage` は `registeredGroups[chatJid]` を参照していない。
-メッセージは thread であっても DB に保存される。スキップされるのは `startMessageLoop` 側。
+重要な点として、メッセージは次の 2 段階でフィルタリングされる。
+
+1. **`discord.ts` 側（チャンネルアダプター）**: 未登録チャンネル/スレッドのメッセージはここでドロップされる。ただし、スレッドの親チャンネルが `thread_defaults` を持つ場合は例外として `onMessage` まで通す。
+2. **`onMessage` コールバック（`index.ts`）**: `registeredGroups[chatJid]` を参照する。未登録かつ `msg.parent_jid` がある場合は `autoRegisterThread` を呼んで子 group を登録し、処理を継続する。親に `thread_defaults` がなければ `return` で早期終了する。`storeMessage` は最終的にすべてのチェックを通過したメッセージにのみ呼ばれる。
 
 ### thread 自動登録の差し込み点
 
-`startMessageLoop` 内の以下の箇所が自然な差し込み点になる。
+実際の実装では `onMessage` コールバック内が差し込み点になっている。
 
 ```ts
-// 現状
-const group = registeredGroups[chatJid];
-if (!group) continue;
-
-// 拡張後
-const group = registeredGroups[chatJid];
-if (!group) {
-  // thread 自動登録を試みる
-  const registered = await tryAutoRegisterThread(chatJid, msg);
-  if (!registered) continue;
-  // 登録完了 → 次のポーリングサイクルで処理（同サイクルでは処理しない）
-  continue;
+// src/index.ts — onMessage コールバック内
+if (!registeredGroups[chatJid] && msg.parent_jid) {
+  const parent = registeredGroups[msg.parent_jid];
+  if (parent?.thread_defaults) {
+    autoRegisterThread(chatJid, msg, parent);
+    // 登録したので以降の storeMessage / allowlist 処理を通常通り実行する
+  } else {
+    return; // parent が thread_defaults を持たない → ドロップ
+  }
 }
 ```
 
-自動登録後は **同サイクルで処理しない**。`registeredGroups` への反映と `lastAgentTimestamp` の初期化が揃ってから、次のポーリングで通常フローに乗せるのが安全。
+メッセージは自動登録完了後もそのまま `storeMessage` まで流れる。`startMessageLoop` 側では次のポーリングサイクルで通常フローに乗る。
 
-`tryAutoRegisterThread` の内部ロジック:
+`autoRegisterThread` の内部ロジック:
 
-1. `chatJid` から親チャンネルの JID を導出する（Discord の場合 `dc:{parentChannelId}`）
-2. `registeredGroups` から親 group を探す
-3. 親に `thread_defaults` がなければ `return false`
-4. `thread_defaults` の内容で子 group を組み立てて `registerGroup(chatJid, childGroup)` を呼ぶ
+1. `msg.parent_jid` から親 group を `registeredGroups` で直接引く
+2. 親に `thread_defaults` がなければ早期 `return`（呼び出し元でガード済み）
+3. `thread_defaults` の内容（`type ?? 'thread'`、`requiresTrigger` など）で子 group を組み立てて `setRegisteredGroup()` で DB に保存し `registeredGroups[chatJid]` に反映する
 
 ### トリガー判定
 

--- a/docs/thread-based-architecture/thread-implementation-plan.md
+++ b/docs/thread-based-architecture/thread-implementation-plan.md
@@ -22,7 +22,7 @@
 - 親 group と別の `chat_jid` を持つ
 - 親 group と別の Claude session を持つ
 - 親 group の `thread_defaults` があるときだけ、自動登録される
-- `type: 'thread'` として DB に保存される
+- DB に保存される `type` は `thread_defaults.type` を優先し、未指定時は `thread` になる
 - 権限レベルは `chat` と同じ非特権側で開始する
 - 将来の thread 用共有設定を継承できる構造を持つ
 

--- a/docs/thread-based-architecture/thread-implementation-plan.md
+++ b/docs/thread-based-architecture/thread-implementation-plan.md
@@ -1,0 +1,291 @@
+# Thread 実装計画
+
+この文書は、NanoClaw における `thread` を実装するための作業計画書である。`docs/thread-based-architecture/` 配下の設計意図に沿い、`thread` を VRC-AI-Bot の PlaceType の移植ではなく、**親 group から派生する作業単位** として実装する。
+
+## 目的
+
+- Discord thread を NanoClaw の `thread` group として扱えるようにする
+- `chat` と `thread` の違いを、別 JID と別 Claude session で表現する
+- 将来的に通常 group 用設定と thread 用共有設定を分けられるよう、拡張しやすい形にする
+
+## 非目的
+
+- VRC-AI-Bot の `PlaceType` / `Scope` / `ChatBehavior` を全面移植すること
+- `thread` 用に別 `folder` を自動生成すること
+- `thread` 用に `chat` と別の独立パーミッション階層を作ること
+- Discord 上のすべての thread を自動的に NanoClaw の `thread` と見なすこと
+
+## 到達状態
+
+実装後の `thread` は次の性質を持つ。
+
+- 親 group と別の `chat_jid` を持つ
+- 親 group と別の Claude session を持つ
+- 親 group の `thread_defaults` があるときだけ、自動登録される
+- `type: 'thread'` として DB に保存される
+- 権限レベルは `chat` と同じ非特権側で開始する
+- 将来の thread 用共有設定を継承できる構造を持つ
+
+## 現状整理
+
+現状のコードでは `GroupType` に `thread` は存在するが、挙動の大半は `chat` と同じである。
+
+- `thread` は有効な `GroupType` として解決される
+- `chat` / `thread` はどちらも非特権扱いで、デフォルト allowed tools は `["Read"]`
+- Discord adapter は thread を正しく判定していない
+- `place_type` は常に `guild_text`
+- `is_thread` は常に `false`
+- `thread_defaults` の型、保存、継承、自動登録は未実装
+
+## 実装方針
+
+実装は 3 フェーズで進める。
+
+### Phase 1: Discord adapter で thread を正しく認識する
+
+目的:
+- Discord の message が thread 上かどうかを正しく識別する
+- `chat_jid` が親 channel ではなく thread id を指す状態を前提に、メタデータを正しく流す
+
+変更内容:
+- `src/channels/discord.ts`
+  - `message.channel.isThread()` を使って thread 判定する
+  - `place_type` を channel type に応じて埋める
+    - public thread
+    - private thread
+    - forum post thread
+    - それ以外は guild text
+  - `is_thread` を正しく設定する
+  - `chatName` は親 channel と thread 名を含む形にする
+
+完了条件:
+- thread 上の message を受けたとき、`chat_jid` が `dc:{threadId}` になる
+- `InboundMessage.is_thread === true` になる
+- ログと chat metadata 上で thread が識別できる
+
+### Phase 2: `thread_defaults` と自動登録を入れる
+
+目的:
+- 親 group に `thread_defaults` があるとき、その thread を派生 group として自動登録する
+
+データモデル:
+- `RegisteredGroup` に `thread_defaults` を追加する
+- `thread_defaults` は少なくとも以下を持てるようにする
+  - `type`
+  - `requiresTrigger`
+  - `containerConfig`
+  - 将来の thread 用共有設定
+
+保存:
+- DB に `thread_defaults` 用 JSON カラムを追加する
+- `register_group` / `update_group` IPC で保存できるようにする
+
+自動登録ルール:
+- thread message を受信したが、その `chat_jid` に対応する登録 group がない場合のみ発火
+- 親 channel の `chat_jid` を導出し、親 group を探す
+- 親 group に `thread_defaults` がなければ何もしない
+- 親 group に `thread_defaults` があれば、その内容を使って子 group を登録する
+- 子 group の `type` は `thread`
+- 子 group の `jid` は `dc:{threadId}`
+- 子 group の `folder` は親 group と同じ値を使う
+  - `thread` は別 folder を持たない
+  - 分離は JID と session で行う
+
+命名:
+- 子 group の `name` は Discord 上の表示名を使う
+- `added_at` は自動登録時刻
+
+完了条件:
+- 親 group に `thread_defaults` がある状態で thread message を送ると、自動で子 group が登録される
+- 親 group に `thread_defaults` がない場合は登録されない
+
+### Phase 3: Claude session を group 単位で分離する
+
+目的:
+- `thread` が親 group と別の会話履歴を持つようにする
+
+現状:
+- session は `group.folder` 単位で保存されている
+- このままだと親と thread が同じ folder を共有した場合、同じ session に流れ込む
+
+変更内容:
+- session のキーを `group.folder` から **group を一意に識別できるキー** に変更する
+- このキーは `jid` ベースにするのが最も単純
+
+変更対象:
+- sessions テーブル
+- `getAllSessions()`
+- `setSession()`
+- `src/index.ts`
+- `src/task-scheduler.ts`
+- `src/container-runner.ts` に渡す session lookup
+
+要件:
+- `chat` と `thread` が同じ folder を共有していても、Claude session は混ざらない
+- session の分離単位は **group** である
+- 将来、thread 用共有設定を変える前提と整合する
+
+マイグレーション方針:
+- 既存の `group_folder` ベース session をそのまま上書き移行しない
+- 新しいキー列を導入するか、sessions テーブルを group id ベースに置き換える
+- 旧 session は必要なら読み取り時にフォールバックしてもよいが、書き込みは新キーに統一する
+
+完了条件:
+- 親 group と thread group が別 session を持つ
+- 片方の会話履歴がもう片方に流れない
+
+## サーバー側のメッセージ処理
+
+### 現状の処理フロー
+
+`index.ts` のメッセージ処理は次の 2 層で動く。
+
+```
+onMessage callback (channel → index.ts)
+  └── storeMessage(msg)   ← 登録済みかどうかに関わらず DB に保存
+
+startMessageLoop (POLL_INTERVAL ごと)
+  └── getNewMessages(registered jids only)
+        └── registeredGroups[chatJid] が undefined → continue (スキップ)
+              └── トリガー判定 → queue.enqueueMessageCheck or sendMessage
+                    └── processGroupMessages → runAgent
+```
+
+重要な点として、`onMessage` は `registeredGroups[chatJid]` を参照していない。
+メッセージは thread であっても DB に保存される。スキップされるのは `startMessageLoop` 側。
+
+### thread 自動登録の差し込み点
+
+`startMessageLoop` 内の以下の箇所が自然な差し込み点になる。
+
+```ts
+// 現状
+const group = registeredGroups[chatJid];
+if (!group) continue;
+
+// 拡張後
+const group = registeredGroups[chatJid];
+if (!group) {
+  // thread 自動登録を試みる
+  const registered = await tryAutoRegisterThread(chatJid, msg);
+  if (!registered) continue;
+  // 登録完了 → 次のポーリングサイクルで処理（同サイクルでは処理しない）
+  continue;
+}
+```
+
+自動登録後は **同サイクルで処理しない**。`registeredGroups` への反映と `lastAgentTimestamp` の初期化が揃ってから、次のポーリングで通常フローに乗せるのが安全。
+
+`tryAutoRegisterThread` の内部ロジック:
+
+1. `chatJid` から親チャンネルの JID を導出する（Discord の場合 `dc:{parentChannelId}`）
+2. `registeredGroups` から親 group を探す
+3. 親に `thread_defaults` がなければ `return false`
+4. `thread_defaults` の内容で子 group を組み立てて `registerGroup(chatJid, childGroup)` を呼ぶ
+
+### トリガー判定
+
+thread group の `requiresTrigger` は `thread_defaults` から継承する。親が `requiresTrigger: false` の group なら、thread も同様に全メッセージで起動する。自動登録時に子 group の `requiresTrigger` に明示的にセットしておく。
+
+### session キーの問題
+
+現状、session は `group.folder` をキーに保存している（`runAgent` 内）。
+
+```ts
+const sessionId = sessions[group.folder];   // index.ts:277
+sessions[group.folder] = output.newSessionId; // index.ts:304
+```
+
+親 group と thread group が同じ `folder` を共有する設計のため、このままだと Claude session が混ざる。Phase 3 で session キーを `chatJid`（group の jid）に変更することでこれを解消する。
+
+変更が必要な箇所:
+
+- `sessions` の型を `Record<string, string>` のまま維持しつつ、キーを `folder` → `jid` に変更
+- `getAllSessions()` / `setSession()` の DB スキーマも同様
+- `task-scheduler.ts` も同じキーで session を参照しているため追従が必要
+
+マイグレーション方針は `group-type-spec.md` の方針（新キー列を追加、書き込みを新キーに統一）に従う。
+
+## 将来拡張
+
+### thread 用共有設定
+
+`thread` の価値は独立パーミッションではなく、**会話分離と thread 群に対する設定差し替え可能性** にある。
+
+そのため、将来は `agent` という名前に限定せず、通常 group 用設定と thread 用共有設定を持てるようにする。
+
+最低限入れたいもの:
+- `allowedTools`
+- `mcpServers`
+- `skills`
+- 継承フラグ
+
+適用順序:
+- group type のデフォルト
+- 通常 group 用設定
+- `thread_defaults` から継承された thread 用共有設定
+
+### cleanup / archive
+
+初期実装では必須ではない。必要になったら以下を追加する。
+
+- Discord thread archive と group 状態の同期
+- 一定期間非アクティブな thread group の cleanup
+- override thread と通常 thread の終了処理の違い
+
+## 変更対象一覧
+
+- `src/types.ts`
+  - `RegisteredGroup` に `thread_defaults` を追加
+  - 将来の thread 用共有設定型の追加余地を作る
+- `src/db.ts`
+  - `thread_defaults` の保存・読込
+  - sessions の識別子変更
+- `src/ipc.ts`
+  - `register_group` / `update_group` に `thread_defaults` を追加
+- `src/channels/discord.ts`
+  - thread 判定
+  - parent channel 解決
+  - auto registration 起点
+- `src/index.ts`
+  - group lookup と session lookup のキー変更に追従
+- `src/task-scheduler.ts`
+  - session lookup のキー変更に追従
+- `src/container-runner.ts`
+  - 将来の thread 用共有設定注入点を整理
+
+## テスト計画
+
+### 単体テスト
+
+- `thread` message で `is_thread` が `true` になる
+- `place_type` が thread 種別に応じて正しく入る
+- 親 group に `thread_defaults` があるときだけ子 group が登録される
+- 自動登録された子 group が `type: 'thread'` になる
+- 親と子が同じ folder を共有しても session が分離される
+
+### 回帰テスト
+
+- 既存の `chat` group の挙動が変わらない
+- `main` / `override` の権限判定が変わらない
+- scheduler が group session を正しく引ける
+- IPC 認可が `chat` / `thread` を非特権として扱い続ける
+
+## 実装順序
+
+1. Discord thread 判定を入れる
+2. `thread_defaults` の型・DB・IPC を入れる
+3. 自動登録を入れる
+4. session 識別子を group 単位に変更する
+5. テストを追加する
+6. 将来の thread 用共有設定の拡張ポイントを整える
+
+## 判断基準
+
+実装中に迷ったら、次の原則を優先する。
+
+- PlaceType を増やして解決しない
+- `thread` の本質は別 folder ではなく別 session
+- 差分は権限よりライフサイクルに置く
+- 将来の設定差し替えは thread ごとではなく thread 群で共有する
+- 親 group が明示的に opt-in した thread だけを NanoClaw の `thread` と見なす

--- a/docs/thread-based-architecture/thread-implementation-plan.md
+++ b/docs/thread-based-architecture/thread-implementation-plan.md
@@ -92,7 +92,8 @@
   - 分離は JID と session で行う
 
 命名:
-- 子 group の `name` は Discord 上の表示名を使う
+- 子 group の `name` は `msg.sender_name` から導出した値を使う
+  - 例: `Thread (from Alice)`
 - `added_at` は自動登録時刻
 
 完了条件:

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -44,6 +44,14 @@ vi.mock('discord.js', () => {
     DirectMessages: 8,
   };
 
+  const ChannelType = {
+    GuildText: 0,
+    GuildAnnouncement: 5,
+    PublicThread: 11,
+    PrivateThread: 12,
+    GuildForum: 15,
+  };
+
   class MockClient {
     eventHandlers = new Map<string, Handler[]>();
     user: any = { id: '999888777', tag: 'Andy#1234' };
@@ -92,11 +100,16 @@ vi.mock('discord.js', () => {
   // Mock TextChannel type
   class TextChannel {}
 
+  // Mock ThreadChannel type
+  class ThreadChannel {}
+
   return {
     Client: MockClient,
     Events,
     GatewayIntentBits,
+    ChannelType,
     TextChannel,
+    ThreadChannel,
   };
 });
 
@@ -137,15 +150,35 @@ function createMessage(overrides: {
   attachments?: Map<string, any>;
   reference?: { messageId?: string };
   mentionsBotId?: boolean;
+  isThread?: boolean;
+  parentId?: string;
+  parentName?: string;
 }) {
   const channelId = overrides.channelId ?? '1234567890123456';
   const authorId = overrides.authorId ?? '55512345';
   const botId = '999888777'; // matches mock client user id
+  const isThreadChannel = overrides.isThread ?? false;
 
   const mentionsMap = new Map();
   if (overrides.mentionsBotId) {
     mentionsMap.set(botId, { id: botId });
   }
+
+  const channel = {
+    name: overrides.channelName ?? 'general',
+    type: 0, // GuildText
+    isThread: () => isThreadChannel,
+    parentId: overrides.parentId ?? null,
+    parent: overrides.parentName
+      ? { name: overrides.parentName, type: 0 }
+      : null,
+    messages: {
+      fetch: vi.fn().mockResolvedValue({
+        author: { username: 'Bob', displayName: 'Bob' },
+        member: { displayName: 'Bob' },
+      }),
+    },
+  };
 
   return {
     channelId,
@@ -162,15 +195,7 @@ function createMessage(overrides: {
       ? { displayName: overrides.memberDisplayName }
       : null,
     guild: overrides.guildName ? { name: overrides.guildName } : null,
-    channel: {
-      name: overrides.channelName ?? 'general',
-      messages: {
-        fetch: vi.fn().mockResolvedValue({
-          author: { username: 'Bob', displayName: 'Bob' },
-          member: { displayName: 'Bob' },
-        }),
-      },
-    },
+    channel,
     mentions: {
       users: mentionsMap,
     },
@@ -775,6 +800,152 @@ describe('DiscordChannel', () => {
     it('has name "discord"', () => {
       const channel = new DiscordChannel('test-token', createTestOpts());
       expect(channel.name).toBe('discord');
+    });
+  });
+
+  // --- Thread detection ---
+
+  describe('thread detection', () => {
+    it('sets is_thread=true and place_type=public_thread for thread messages', async () => {
+      const threadId = '9999000000000001';
+      const parentId = '1234567890123456';
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          [`dc:${threadId}`]: {
+            name: 'Thread',
+            folder: 'test-server',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        channelId: threadId,
+        content: 'Hello from thread',
+        guildName: 'Test Server',
+        channelName: 'my-thread',
+        isThread: true,
+        parentId,
+        parentName: 'general',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        `dc:${threadId}`,
+        expect.objectContaining({
+          is_thread: true,
+          place_type: 'public_thread',
+          parent_jid: `dc:${parentId}`,
+        }),
+      );
+    });
+
+    it('includes parent name in chatName for thread messages', async () => {
+      const threadId = '9999000000000002';
+      const parentId = '1234567890123456';
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          [`dc:${threadId}`]: {
+            name: 'Thread',
+            folder: 'test-server',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        channelId: threadId,
+        content: 'Thread message',
+        guildName: 'My Guild',
+        channelName: 'task-thread',
+        isThread: true,
+        parentId,
+        parentName: 'general',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        `dc:${threadId}`,
+        expect.any(String),
+        'My Guild #general > task-thread',
+        'discord',
+        true,
+      );
+    });
+
+    it('allows thread message through when parent has thread_defaults', async () => {
+      const threadId = '9999000000000003';
+      const parentId = '1234567890123456';
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          [`dc:${parentId}`]: {
+            name: 'Parent Channel',
+            folder: 'test-server',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+            thread_defaults: { type: 'thread' as const },
+          },
+        })),
+      });
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        channelId: threadId,
+        content: 'First message in new thread',
+        guildName: 'Test Server',
+        channelName: 'new-thread',
+        isThread: true,
+        parentId,
+        parentName: 'general',
+      });
+      await triggerMessage(msg);
+
+      // Should deliver even though thread itself is not registered yet
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        `dc:${threadId}`,
+        expect.objectContaining({
+          is_thread: true,
+          parent_jid: `dc:${parentId}`,
+        }),
+      );
+    });
+
+    it('drops thread message when parent has no thread_defaults', async () => {
+      const threadId = '9999000000000004';
+      const parentId = '1234567890123456';
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          [`dc:${parentId}`]: {
+            name: 'Parent Channel',
+            folder: 'test-server',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+            // no thread_defaults
+          },
+        })),
+      });
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        channelId: threadId,
+        content: 'Thread message nobody asked for',
+        guildName: 'Test Server',
+        channelName: 'random-thread',
+        isThread: true,
+        parentId,
+        parentName: 'general',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -46,6 +46,8 @@ vi.mock('discord.js', () => {
 
   const ChannelType = {
     GuildText: 0,
+    DM: 1,
+    GroupDM: 3,
     GuildAnnouncement: 5,
     PublicThread: 11,
     PrivateThread: 12,
@@ -153,6 +155,7 @@ function createMessage(overrides: {
   isThread?: boolean;
   parentId?: string;
   parentName?: string;
+  channelType?: number;
 }) {
   const channelId = overrides.channelId ?? '1234567890123456';
   const authorId = overrides.authorId ?? '55512345';
@@ -166,7 +169,7 @@ function createMessage(overrides: {
 
   const channel = {
     name: overrides.channelName ?? 'general',
-    type: 0, // GuildText
+    type: overrides.channelType ?? 0,
     isThread: () => isThreadChannel,
     parentId: overrides.parentId ?? null,
     parent: overrides.parentName
@@ -394,6 +397,7 @@ describe('DiscordChannel', () => {
         content: 'Hello',
         guildName: undefined,
         authorDisplayName: 'Alice',
+        channelType: 1,
       });
       await triggerMessage(msg);
 
@@ -403,6 +407,10 @@ describe('DiscordChannel', () => {
         'Alice',
         'discord',
         false,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ place_type: 'chat_channel' }),
       );
     });
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,9 +1,11 @@
 import {
+  ChannelType,
   Client,
   Events,
   GatewayIntentBits,
   Message,
   TextChannel,
+  ThreadChannel,
 } from 'discord.js';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
@@ -15,8 +17,22 @@ import {
   InboundMessage,
   OnChatMetadata,
   OnInboundMessage,
+  PlaceType,
   RegisteredGroup,
 } from '../types.js';
+
+/** Discord channel type から PlaceType を解決する */
+function resolvePlaceType(channel: Message['channel']): PlaceType {
+  if (channel.isThread()) {
+    if (channel.type === ChannelType.PrivateThread) return 'private_thread';
+    if (channel.parent?.type === ChannelType.GuildForum) {
+      return 'forum_post_thread';
+    }
+    return 'public_thread';
+  }
+  if (channel.type === ChannelType.GuildAnnouncement) return 'guild_announcement';
+  return 'guild_text';
+}
 
 export interface DiscordChannelOpts {
   onMessage: OnInboundMessage;
@@ -50,6 +66,7 @@ export class DiscordChannel implements Channel {
       // Ignore bot messages (including own)
       if (message.author.bot) return;
 
+      const isThread = message.channel.isThread();
       const channelId = message.channelId;
       const chatJid = `dc:${channelId}`;
       let content = message.content;
@@ -64,10 +81,22 @@ export class DiscordChannel implements Channel {
       // Determine chat name
       let chatName: string;
       if (message.guild) {
-        const textChannel = message.channel as TextChannel;
-        chatName = `${message.guild.name} #${textChannel.name}`;
+        if (isThread && message.channel.isThread()) {
+          const thread = message.channel as ThreadChannel;
+          const parentName = thread.parent?.name || 'unknown';
+          chatName = `${message.guild.name} #${parentName} > ${thread.name}`;
+        } else {
+          const textChannel = message.channel as TextChannel;
+          chatName = `${message.guild.name} #${textChannel.name}`;
+        }
       } else {
         chatName = senderName;
+      }
+
+      // Resolve parent JID for thread messages
+      let parentJid: string | undefined;
+      if (isThread && message.channel.isThread() && message.channel.parentId) {
+        parentJid = `dc:${message.channel.parentId}`;
       }
 
       // Translate Discord @bot mentions into TRIGGER_PATTERN format.
@@ -142,19 +171,34 @@ export class DiscordChannel implements Channel {
         isGroup,
       );
 
-      // Only deliver full message for registered groups
+      // Only deliver full message for registered groups.
+      // Exception: thread messages from channels whose parent has thread_defaults
+      // are allowed through so index.ts can auto-register the thread group.
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) {
-        logger.debug(
-          { chatJid, chatName },
-          'Message from unregistered Discord channel',
-        );
-        return;
+        if (parentJid) {
+          const parentGroup = this.opts.registeredGroups()[parentJid];
+          if (parentGroup?.thread_defaults) {
+            // Auto-registration candidate — fall through to deliver the message
+          } else {
+            logger.debug(
+              { chatJid, chatName },
+              'Message from unregistered Discord thread (no parent thread_defaults)',
+            );
+            return;
+          }
+        } else {
+          logger.debug(
+            { chatJid, chatName },
+            'Message from unregistered Discord channel',
+          );
+          return;
+        }
       }
 
       // Deliver message — startMessageLoop() will pick it up.
       // InboundMessage extends NewMessage with Discord-specific metadata
-      // (place_type, actor_role, is_thread) that is callback-only and not persisted.
+      // (place_type, actor_role, is_thread, parent_jid) that is callback-only and not persisted.
       const inbound: InboundMessage = {
         id: msgId,
         chat_jid: chatJid,
@@ -163,9 +207,10 @@ export class DiscordChannel implements Channel {
         content,
         timestamp,
         is_from_me: false,
-        place_type: 'guild_text',
+        place_type: resolvePlaceType(message.channel),
         actor_role: 'owner',
-        is_thread: false,
+        is_thread: isThread,
+        parent_jid: parentJid,
       };
       this.opts.onMessage(chatJid, inbound);
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -30,7 +30,8 @@ function resolvePlaceType(channel: Message['channel']): PlaceType {
     }
     return 'public_thread';
   }
-  if (channel.type === ChannelType.GuildAnnouncement) return 'guild_announcement';
+  if (channel.type === ChannelType.GuildAnnouncement)
+    return 'guild_announcement';
   return 'guild_text';
 }
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -30,6 +30,9 @@ function resolvePlaceType(channel: Message['channel']): PlaceType {
     }
     return 'public_thread';
   }
+  if (channel.type === ChannelType.DM || channel.type === ChannelType.GroupDM) {
+    return 'chat_channel';
+  }
   if (channel.type === ChannelType.GuildAnnouncement)
     return 'guild_announcement';
   return 'guild_text';

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -88,6 +88,7 @@ vi.mock('child_process', async () => {
 
 import { runContainerAgent, ContainerOutput } from './container-runner.js';
 import type { RegisteredGroup } from './types.js';
+import { spawn } from 'child_process';
 
 const testGroup: RegisteredGroup = {
   name: 'Test Group',
@@ -113,6 +114,7 @@ function emitOutputMarker(
 
 describe('container-runner timeout behavior', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers();
     fakeProc = createFakeProcess();
   });
@@ -206,5 +208,64 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+
+  it('uses folder-shared session namespace for thread groups', async () => {
+    const resultPromise = runContainerAgent(
+      testGroup,
+      {
+        ...testInput,
+        chatJid: 'dc:thread-1',
+        groupType: 'thread',
+      },
+      () => {},
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'ok',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const spawnCalls = vi.mocked(spawn).mock.calls;
+    const args = spawnCalls[spawnCalls.length - 1][1] as string[];
+    const joined = args.join(' ');
+    expect(joined).toContain(
+      '/tmp/nanoclaw-test-data/sessions/folder-test-group/.claude:/home/node/.claude',
+    );
+  });
+
+  it('uses chatJid-isolated session namespace for main groups', async () => {
+    const resultPromise = runContainerAgent(
+      {
+        ...testGroup,
+        type: 'main',
+      },
+      {
+        ...testInput,
+        chatJid: 'main@g.us',
+        groupType: 'main',
+      },
+      () => {},
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'ok',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const spawnCalls = vi.mocked(spawn).mock.calls;
+    const args = spawnCalls[spawnCalls.length - 1][1] as string[];
+    const joined = args.join(' ');
+    expect(joined).toContain(
+      '/tmp/nanoclaw-test-data/sessions/jid-main%40g.us/.claude:/home/node/.claude',
+    );
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -16,7 +16,11 @@ import {
   IDLE_TIMEOUT,
   TIMEZONE,
 } from './config.js';
-import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import {
+  encodeIpcNamespaceKey,
+  resolveGroupFolderPath,
+  resolveGroupIpcPathByJid,
+} from './group-folder.js';
 import { logger } from './logger.js';
 import {
   CONTAINER_HOST_GATEWAY,
@@ -58,9 +62,23 @@ interface VolumeMount {
   readonly: boolean;
 }
 
+function resolveSessionNamespace(
+  group: RegisteredGroup,
+  groupType: GroupType,
+  chatJid: string,
+): string {
+  // main / override は共有せず、chatJid ごとに分離する
+  if (groupType === 'main' || groupType === 'override') {
+    return `jid-${encodeIpcNamespaceKey(chatJid)}`;
+  }
+  // chat / thread は同一 folder 内で共有する
+  return `folder-${group.folder}`;
+}
+
 function buildVolumeMounts(
   group: RegisteredGroup,
   groupType: GroupType,
+  chatJid: string,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -117,14 +135,12 @@ function buildVolumeMounts(
     }
   }
 
-  // グループごとの Claude セッションディレクトリ（他のグループから隔離）
-  // グループ間のセッションアクセスを防ぐため、各グループは独自の .claude/ を持ちます
-  const groupSessionsDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
-    '.claude',
-  );
+  // Claude セッションディレクトリの分離ポリシー:
+  // - main/override: chatJid ごとに分離
+  // - chat/thread: folder 単位で共有
+  const sessionNamespace = resolveSessionNamespace(group, groupType, chatJid);
+  const groupSessionsRoot = path.join(DATA_DIR, 'sessions', sessionNamespace);
+  const groupSessionsDir = path.join(groupSessionsRoot, '.claude');
   fs.mkdirSync(groupSessionsDir, { recursive: true });
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
   const defaultSettingsEnv: Record<string, string> = {
@@ -214,7 +230,7 @@ function buildVolumeMounts(
 
   // グループごとの IPC ネームスペース: 各グループは独自の IPC ディレクトリを持ちます
   // これにより、IPC を介したグループを跨ぐ権限昇格を防ぎます
-  const groupIpcDir = resolveGroupIpcPath(group.folder);
+  const groupIpcDir = resolveGroupIpcPathByJid(chatJid);
   fs.mkdirSync(path.join(groupIpcDir, 'messages'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'tasks'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
@@ -231,12 +247,7 @@ function buildVolumeMounts(
     'agent-runner',
     'src',
   );
-  const groupAgentRunnerDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
-    'agent-runner-src',
-  );
+  const groupAgentRunnerDir = path.join(groupSessionsRoot, 'agent-runner-src');
   if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
     fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
   }
@@ -319,7 +330,7 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.groupType);
+  const mounts = buildVolumeMounts(group, input.groupType, input.chatJid);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
   const containerArgs = buildContainerArgs(mounts, containerName);
@@ -683,10 +694,11 @@ export async function runContainerAgent(
 }
 
 export function writeTasksSnapshot(
-  groupFolder: string,
+  groupJid: string,
   isPrivileged: boolean,
   tasks: Array<{
     id: string;
+    groupJid: string;
     groupFolder: string;
     prompt: string;
     schedule_type: string;
@@ -696,13 +708,13 @@ export function writeTasksSnapshot(
   }>,
 ): void {
   // フィルタリングされたタスクをグループの IPC ディレクトリに書き込む
-  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  const groupIpcDir = resolveGroupIpcPathByJid(groupJid);
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   // 特権グループ（main/override）はすべてのタスクを表示でき、非特権グループは自身のタスクのみを表示できる
   const filteredTasks = isPrivileged
     ? tasks
-    : tasks.filter((t) => t.groupFolder === groupFolder);
+    : tasks.filter((t) => t.groupJid === groupJid);
 
   const tasksFile = path.join(groupIpcDir, 'current_tasks.json');
   fs.writeFileSync(tasksFile, JSON.stringify(filteredTasks, null, 2));
@@ -721,11 +733,11 @@ export interface AvailableGroup {
  * 非特権グループにはこのファイルは空リストとして書き込まれます。
  */
 export function writeGroupsSnapshot(
-  groupFolder: string,
+  groupJid: string,
   isPrivileged: boolean,
   groups: AvailableGroup[],
 ): void {
-  const groupIpcDir = resolveGroupIpcPath(groupFolder);
+  const groupIpcDir = resolveGroupIpcPathByJid(groupJid);
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   // 特権グループ（main/override）はすべてのグループを表示でき、他は何も表示できない（グループをアクティブ化できないため）

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -630,4 +630,9 @@ describe('_shouldMigrateSessionKey', () => {
     expect(_shouldMigrateSessionKey('discord_main')).toBe(false);
     expect(_shouldMigrateSessionKey('my-group_folder')).toBe(false);
   });
+
+  it('rejects non-JID garbled keys', () => {
+    expect(_shouldMigrateSessionKey('!!!invalid!!!')).toBe(false);
+    expect(_shouldMigrateSessionKey('user@invalid-domain')).toBe(false);
+  });
 });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
   _parseContainerConfigJson,
+  _shouldMigrateSessionKey,
   _parseThreadDefaultsJson,
   _sanitizeThreadDefaults,
   _initTestDatabase,
@@ -612,5 +613,21 @@ describe('session accessors', () => {
     setSession('dc:thread', 'thread-sess');
     expect(getSession('dc:parent')).toBe('parent-sess');
     expect(getSession('dc:thread')).toBe('thread-sess');
+  });
+});
+
+describe('_shouldMigrateSessionKey', () => {
+  it('accepts protocol-prefixed keys', () => {
+    expect(_shouldMigrateSessionKey('dc:123456')).toBe(true);
+  });
+
+  it('accepts WhatsApp JID-style keys', () => {
+    expect(_shouldMigrateSessionKey('123456@g.us')).toBe(true);
+    expect(_shouldMigrateSessionKey('123456@s.whatsapp.net')).toBe(true);
+  });
+
+  it('rejects legacy folder keys', () => {
+    expect(_shouldMigrateSessionKey('discord_main')).toBe(false);
+    expect(_shouldMigrateSessionKey('my-group_folder')).toBe(false);
   });
 });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -6,10 +6,13 @@ import {
   deleteTask,
   getAllChats,
   getAllRegisteredGroups,
+  getAllSessions,
   getMessagesSince,
   getNewMessages,
+  getSession,
   getTaskById,
   setRegisteredGroup,
+  setSession,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -497,5 +500,74 @@ describe('registered group type', () => {
       const groups = getAllRegisteredGroups();
       expect(groups[jid].type).toBe(t);
     }
+  });
+
+  it('persists thread_defaults through set/get round-trip', () => {
+    setRegisteredGroup('dc:parent123', {
+      name: 'Parent Channel',
+      folder: 'discord_main',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      type: 'main',
+      thread_defaults: {
+        type: 'thread',
+        requiresTrigger: false,
+        containerConfig: { timeout: 120000 },
+      },
+    });
+
+    const groups = getAllRegisteredGroups();
+    const group = groups['dc:parent123'];
+    expect(group).toBeDefined();
+    expect(group.thread_defaults).toBeDefined();
+    expect(group.thread_defaults!.type).toBe('thread');
+    expect(group.thread_defaults!.requiresTrigger).toBe(false);
+    expect(group.thread_defaults!.containerConfig?.timeout).toBe(120000);
+  });
+
+  it('returns undefined thread_defaults when not set', () => {
+    setRegisteredGroup('dc:nocfg', {
+      name: 'No Config',
+      folder: 'discord_nocfg',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    const groups = getAllRegisteredGroups();
+    expect(groups['dc:nocfg'].thread_defaults).toBeUndefined();
+  });
+});
+
+// --- Session accessors (jid-keyed) ---
+
+describe('session accessors', () => {
+  it('sets and retrieves session by jid', () => {
+    setSession('dc:123456789', 'sess-abc');
+    expect(getSession('dc:123456789')).toBe('sess-abc');
+  });
+
+  it('returns undefined for unknown jid', () => {
+    expect(getSession('dc:unknown')).toBeUndefined();
+  });
+
+  it('overwrites existing session', () => {
+    setSession('dc:111', 'sess-old');
+    setSession('dc:111', 'sess-new');
+    expect(getSession('dc:111')).toBe('sess-new');
+  });
+
+  it('getAllSessions returns all sessions keyed by jid', () => {
+    setSession('dc:aaa', 'sess-1');
+    setSession('dc:bbb', 'sess-2');
+    const sessions = getAllSessions();
+    expect(sessions['dc:aaa']).toBe('sess-1');
+    expect(sessions['dc:bbb']).toBe('sess-2');
+  });
+
+  it('parent and thread groups have independent sessions', () => {
+    setSession('dc:parent', 'parent-sess');
+    setSession('dc:thread', 'thread-sess');
+    expect(getSession('dc:parent')).toBe('parent-sess');
+    expect(getSession('dc:thread')).toBe('thread-sess');
   });
 });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
+  _parseThreadDefaultsJson,
   _initTestDatabase,
   createTask,
   deleteTask,
@@ -535,6 +536,10 @@ describe('registered group type', () => {
 
     const groups = getAllRegisteredGroups();
     expect(groups['dc:nocfg'].thread_defaults).toBeUndefined();
+  });
+
+  it('handles malformed thread_defaults JSON safely', () => {
+    expect(_parseThreadDefaultsJson('{bad-json', 'dc:broken')).toBeUndefined();
   });
 });
 

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
+  _parseContainerConfigJson,
   _parseThreadDefaultsJson,
+  _sanitizeThreadDefaults,
   _initTestDatabase,
   createTask,
   deleteTask,
@@ -540,6 +542,42 @@ describe('registered group type', () => {
 
   it('handles malformed thread_defaults JSON safely', () => {
     expect(_parseThreadDefaultsJson('{bad-json', 'dc:broken')).toBeUndefined();
+  });
+
+  it('sanitizes invalid thread_defaults.type to non-privileged fields only', () => {
+    expect(
+      _sanitizeThreadDefaults(
+        { type: 'main', requiresTrigger: true },
+        'dc:broken-type',
+      ),
+    ).toEqual({ requiresTrigger: true });
+  });
+
+  it('handles malformed container_config JSON safely', () => {
+    expect(_parseContainerConfigJson('{bad-json', 'dc:broken')).toBeUndefined();
+  });
+
+  it('allows parent and thread groups to share the same folder', () => {
+    setRegisteredGroup('dc:parent', {
+      name: 'Parent',
+      folder: 'discord_shared',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      type: 'main',
+    });
+    setRegisteredGroup('dc:thread1', {
+      name: 'Thread',
+      folder: 'discord_shared',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:01:00.000Z',
+      type: 'thread',
+    });
+
+    const groups = getAllRegisteredGroups();
+    expect(groups['dc:parent']).toBeDefined();
+    expect(groups['dc:thread1']).toBeDefined();
+    expect(groups['dc:parent'].folder).toBe('discord_shared');
+    expect(groups['dc:thread1'].folder).toBe('discord_shared');
   });
 });
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -755,13 +755,18 @@ function migrateJsonState(): void {
   }
 
   // sessions.json のマイグレーション
+  // sessions テーブルのキーは group_jid（例: dc:123、tg:456）。
+  // 旧形式はフォルダ名がキーだったため、JID 形式のエントリのみ移行する。
+  const JID_PREFIX_RE = /^[a-z]{2,}:/;
   const sessions = migrateFile('sessions.json') as Record<
     string,
     string
   > | null;
   if (sessions) {
-    for (const [folder, sessionId] of Object.entries(sessions)) {
-      setSession(folder, sessionId);
+    for (const [key, sessionId] of Object.entries(sessions)) {
+      if (JID_PREFIX_RE.test(key)) {
+        setSession(key, sessionId);
+      }
     }
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,6 +12,7 @@ import {
   RegisteredGroup,
   ScheduledTask,
   TaskRunLog,
+  ThreadDefaults,
 } from './types.js';
 
 /** DB の group_type / is_main から GroupType を解決する */
@@ -93,7 +94,7 @@ function createSchema(database: Database.Database): void {
       value TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS sessions (
-      group_folder TEXT PRIMARY KEY,
+      group_jid TEXT PRIMARY KEY,
       session_id TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS registered_groups (
@@ -106,6 +107,23 @@ function createSchema(database: Database.Database): void {
       requires_trigger INTEGER DEFAULT 1
     );
   `);
+
+  // sessions テーブルのスキーマを group_folder → group_jid に移行。
+  // 個人プロジェクトのため後方互換不要。旧テーブルが残っている場合は DROP して再作成。
+  try {
+    const hasOldColumn = (database
+      .prepare(`PRAGMA table_info(sessions)`)
+      .all() as Array<{ name: string }>)
+      .some((col) => col.name === 'group_folder');
+    if (hasOldColumn) {
+      database.exec(`DROP TABLE sessions`);
+      database.exec(
+        `CREATE TABLE IF NOT EXISTS sessions (group_jid TEXT PRIMARY KEY, session_id TEXT NOT NULL)`,
+      );
+    }
+  } catch {
+    /* テーブルが存在しないか、すでに移行済み */
+  }
 
   // context_mode カラムが存在しない場合は追加（既存 DB のマイグレーション）
   try {
@@ -149,6 +167,15 @@ function createSchema(database: Database.Database): void {
     );
     database.exec(
       `UPDATE registered_groups SET group_type = 'main' WHERE is_main = 1`,
+    );
+  } catch {
+    /* カラムはすでに存在します */
+  }
+
+  // thread_defaults カラムが存在しない場合は追加
+  try {
+    database.exec(
+      `ALTER TABLE registered_groups ADD COLUMN thread_defaults TEXT`,
     );
   } catch {
     /* カラムはすでに存在します */
@@ -547,27 +574,29 @@ export function setRouterState(key: string, value: string): void {
 }
 
 // --- セッション・アクセッサー ---
+// sessions テーブルのキーは group_jid（例: dc:123456789）。
+// Phase 3 でセッション分離を group 単位に変更した。
 
-export function getSession(groupFolder: string): string | undefined {
+export function getSession(groupJid: string): string | undefined {
   const row = db
-    .prepare('SELECT session_id FROM sessions WHERE group_folder = ?')
-    .get(groupFolder) as { session_id: string } | undefined;
+    .prepare('SELECT session_id FROM sessions WHERE group_jid = ?')
+    .get(groupJid) as { session_id: string } | undefined;
   return row?.session_id;
 }
 
-export function setSession(groupFolder: string, sessionId: string): void {
+export function setSession(groupJid: string, sessionId: string): void {
   db.prepare(
-    'INSERT OR REPLACE INTO sessions (group_folder, session_id) VALUES (?, ?)',
-  ).run(groupFolder, sessionId);
+    'INSERT OR REPLACE INTO sessions (group_jid, session_id) VALUES (?, ?)',
+  ).run(groupJid, sessionId);
 }
 
 export function getAllSessions(): Record<string, string> {
   const rows = db
-    .prepare('SELECT group_folder, session_id FROM sessions')
-    .all() as Array<{ group_folder: string; session_id: string }>;
+    .prepare('SELECT group_jid, session_id FROM sessions')
+    .all() as Array<{ group_jid: string; session_id: string }>;
   const result: Record<string, string> = {};
   for (const row of rows) {
-    result[row.group_folder] = row.session_id;
+    result[row.group_jid] = row.session_id;
   }
   return result;
 }
@@ -590,6 +619,7 @@ export function getRegisteredGroup(
         requires_trigger: number | null;
         is_main: number | null;
         group_type: string | null;
+        thread_defaults: string | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -613,6 +643,9 @@ export function getRegisteredGroup(
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     type: groupType,
+    thread_defaults: row.thread_defaults
+      ? (JSON.parse(row.thread_defaults) as ThreadDefaults)
+      : undefined,
   };
 }
 
@@ -630,8 +663,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   }
   const groupType = VALID_GROUP_TYPES.has(rawType) ? rawType : 'chat';
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type, thread_defaults)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -642,6 +675,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.requiresTrigger === undefined ? 1 : group.requiresTrigger ? 1 : 0,
     groupType === 'main' || groupType === 'override' ? 1 : 0,
     groupType,
+    group.thread_defaults ? JSON.stringify(group.thread_defaults) : null,
   );
 }
 
@@ -656,6 +690,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     requires_trigger: number | null;
     is_main: number | null;
     group_type: string | null;
+    thread_defaults: string | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -678,6 +713,9 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
       type: groupType,
+      thread_defaults: row.thread_defaults
+        ? (JSON.parse(row.thread_defaults) as ThreadDefaults)
+        : undefined,
     };
   }
   return result;

--- a/src/db.ts
+++ b/src/db.ts
@@ -111,10 +111,11 @@ function createSchema(database: Database.Database): void {
   // sessions テーブルのスキーマを group_folder → group_jid に移行。
   // 個人プロジェクトのため後方互換不要。旧テーブルが残っている場合は DROP して再作成。
   try {
-    const hasOldColumn = (database
-      .prepare(`PRAGMA table_info(sessions)`)
-      .all() as Array<{ name: string }>)
-      .some((col) => col.name === 'group_folder');
+    const hasOldColumn = (
+      database.prepare(`PRAGMA table_info(sessions)`).all() as Array<{
+        name: string;
+      }>
+    ).some((col) => col.name === 'group_folder');
     if (hasOldColumn) {
       database.exec(`DROP TABLE sessions`);
       database.exec(

--- a/src/db.ts
+++ b/src/db.ts
@@ -333,36 +333,46 @@ function createSchema(database: Database.Database): void {
   // 旧スキーマ: registered_groups.folder UNIQUE を解除する
   // thread は parent と同じ folder を共有するため、folder の一意制約は不適切。
   try {
-    const tableSql = database
-      .prepare(
-        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'registered_groups'`,
-      )
-      .get() as { sql?: string } | undefined;
-    if (tableSql?.sql?.includes('folder TEXT NOT NULL UNIQUE')) {
-      database.exec(`
-        ALTER TABLE registered_groups RENAME TO registered_groups_old;
-        CREATE TABLE registered_groups (
-          jid TEXT PRIMARY KEY,
-          name TEXT NOT NULL,
-          folder TEXT NOT NULL,
-          trigger_pattern TEXT NOT NULL,
-          added_at TEXT NOT NULL,
-          container_config TEXT,
-          requires_trigger INTEGER DEFAULT 1,
-          is_main INTEGER DEFAULT 0,
-          group_type TEXT DEFAULT 'chat',
-          thread_defaults TEXT
-        );
-        INSERT INTO registered_groups (
-          jid, name, folder, trigger_pattern, added_at, container_config,
-          requires_trigger, is_main, group_type, thread_defaults
-        )
-        SELECT
-          jid, name, folder, trigger_pattern, added_at, container_config,
-          requires_trigger, is_main, group_type, thread_defaults
-        FROM registered_groups_old;
-        DROP TABLE registered_groups_old;
-      `);
+    const indexes = database.prepare(`PRAGMA index_list('registered_groups')`).all() as Array<{
+      name: string;
+      unique: number;
+    }>;
+    const hasUniqueFolderIndex = indexes.some((idx) => {
+      if (idx.unique !== 1) return false;
+      const safeIndexName = idx.name.replace(/'/g, "''");
+      const cols = database
+        .prepare(`PRAGMA index_info('${safeIndexName}')`)
+        .all() as Array<{ name: string }>;
+      return cols.length === 1 && cols[0].name === 'folder';
+    });
+    if (hasUniqueFolderIndex) {
+      const migrate = database.transaction(() => {
+        database.exec(`
+          ALTER TABLE registered_groups RENAME TO registered_groups_old;
+          CREATE TABLE registered_groups (
+            jid TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            folder TEXT NOT NULL,
+            trigger_pattern TEXT NOT NULL,
+            added_at TEXT NOT NULL,
+            container_config TEXT,
+            requires_trigger INTEGER DEFAULT 1,
+            is_main INTEGER DEFAULT 0,
+            group_type TEXT DEFAULT 'chat',
+            thread_defaults TEXT
+          );
+          INSERT INTO registered_groups (
+            jid, name, folder, trigger_pattern, added_at, container_config,
+            requires_trigger, is_main, group_type, thread_defaults
+          )
+          SELECT
+            jid, name, folder, trigger_pattern, added_at, container_config,
+            requires_trigger, is_main, group_type, thread_defaults
+          FROM registered_groups_old;
+          DROP TABLE registered_groups_old;
+        `);
+      });
+      migrate();
     }
   } catch (err) {
     logger.warn(

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,6 +7,7 @@ import { VALID_GROUP_TYPES } from './group-type.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import {
+  ContainerConfig,
   GroupType,
   NewMessage,
   RegisteredGroup,
@@ -36,13 +37,140 @@ function parseGroupType(
   return 'chat';
 }
 
+export function _sanitizeContainerConfig(
+  raw: unknown,
+  jid: string,
+  field: 'container_config' | 'thread_defaults.containerConfig' = 'container_config',
+): ContainerConfig | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    logger.warn({ jid, field }, 'Invalid containerConfig in DB; ignoring');
+    return undefined;
+  }
+  const src = raw as Record<string, unknown>;
+  const out: ContainerConfig = {};
+  if (Object.prototype.hasOwnProperty.call(src, 'timeout')) {
+    if (
+      typeof src.timeout === 'number' &&
+      Number.isFinite(src.timeout) &&
+      src.timeout > 0
+    ) {
+      out.timeout = src.timeout;
+    } else {
+      logger.warn(
+        { jid, field, timeout: src.timeout },
+        'Invalid containerConfig.timeout in DB; ignoring',
+      );
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(src, 'additionalMounts')) {
+    if (Array.isArray(src.additionalMounts)) {
+      const mounts = src.additionalMounts
+        .filter(
+          (m): m is {
+            hostPath: string;
+            containerPath?: string;
+            readonly?: boolean;
+          } =>
+            !!m &&
+            typeof m === 'object' &&
+            typeof (m as { hostPath?: unknown }).hostPath === 'string' &&
+            ((m as { containerPath?: unknown }).containerPath === undefined ||
+              typeof (m as { containerPath?: unknown }).containerPath ===
+                'string') &&
+            ((m as { readonly?: unknown }).readonly === undefined ||
+              typeof (m as { readonly?: unknown }).readonly === 'boolean'),
+        )
+        .map((m) => ({
+          hostPath: m.hostPath,
+          ...(m.containerPath !== undefined
+            ? { containerPath: m.containerPath }
+            : {}),
+          ...(m.readonly !== undefined ? { readonly: m.readonly } : {}),
+        }));
+      if (mounts.length > 0) {
+        out.additionalMounts = mounts;
+      } else if (src.additionalMounts.length > 0) {
+        logger.warn(
+          { jid, field },
+          'Invalid containerConfig.additionalMounts in DB; ignoring',
+        );
+      }
+    } else {
+      logger.warn(
+        { jid, field },
+        'Invalid containerConfig.additionalMounts in DB; ignoring',
+      );
+    }
+  }
+  return out;
+}
+
+export function _parseContainerConfigJson(
+  containerConfig: string | null,
+  jid: string,
+): ContainerConfig | undefined {
+  if (!containerConfig) return undefined;
+  try {
+    return _sanitizeContainerConfig(JSON.parse(containerConfig), jid);
+  } catch (err) {
+    logger.warn(
+      { jid, err },
+      'Invalid container_config JSON in DB; ignoring this value',
+    );
+    return undefined;
+  }
+}
+
+export function _sanitizeThreadDefaults(
+  raw: unknown,
+  jid: string,
+): ThreadDefaults | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    logger.warn({ jid }, 'Invalid thread_defaults in DB; ignoring');
+    return undefined;
+  }
+  const src = raw as Record<string, unknown>;
+  const out: ThreadDefaults = {};
+  if (Object.prototype.hasOwnProperty.call(src, 'type')) {
+    if (src.type === 'chat' || src.type === 'thread') {
+      out.type = src.type;
+    } else {
+      logger.warn(
+        { jid, type: src.type },
+        'Invalid or privileged thread_defaults.type in DB; ignoring',
+      );
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(src, 'requiresTrigger')) {
+    if (typeof src.requiresTrigger === 'boolean') {
+      out.requiresTrigger = src.requiresTrigger;
+    } else {
+      logger.warn(
+        { jid, requiresTrigger: src.requiresTrigger },
+        'Invalid thread_defaults.requiresTrigger in DB; ignoring',
+      );
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(src, 'containerConfig')) {
+    const cc = _sanitizeContainerConfig(
+      src.containerConfig,
+      jid,
+      'thread_defaults.containerConfig',
+    );
+    if (cc) out.containerConfig = cc;
+  }
+  return out;
+}
+
 export function _parseThreadDefaultsJson(
   threadDefaults: string | null,
   jid: string,
 ): ThreadDefaults | undefined {
   if (!threadDefaults) return undefined;
   try {
-    return JSON.parse(threadDefaults) as ThreadDefaults;
+    return _sanitizeThreadDefaults(JSON.parse(threadDefaults), jid);
   } catch (err) {
     logger.warn(
       { jid, err },
@@ -116,7 +244,7 @@ function createSchema(database: Database.Database): void {
     CREATE TABLE IF NOT EXISTS registered_groups (
       jid TEXT PRIMARY KEY,
       name TEXT NOT NULL,
-      folder TEXT NOT NULL UNIQUE,
+      folder TEXT NOT NULL,
       trigger_pattern TEXT NOT NULL,
       added_at TEXT NOT NULL,
       container_config TEXT,
@@ -196,6 +324,44 @@ function createSchema(database: Database.Database): void {
     );
   } catch {
     /* カラムはすでに存在します */
+  }
+
+  // 旧スキーマ: registered_groups.folder UNIQUE を解除する
+  // thread は parent と同じ folder を共有するため、folder の一意制約は不適切。
+  try {
+    const tableSql = database
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'registered_groups'`,
+      )
+      .get() as { sql?: string } | undefined;
+    if (tableSql?.sql?.includes('folder TEXT NOT NULL UNIQUE')) {
+      database.exec(`
+        ALTER TABLE registered_groups RENAME TO registered_groups_old;
+        CREATE TABLE registered_groups (
+          jid TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          folder TEXT NOT NULL,
+          trigger_pattern TEXT NOT NULL,
+          added_at TEXT NOT NULL,
+          container_config TEXT,
+          requires_trigger INTEGER DEFAULT 1,
+          is_main INTEGER DEFAULT 0,
+          group_type TEXT DEFAULT 'chat',
+          thread_defaults TEXT
+        );
+        INSERT INTO registered_groups (
+          jid, name, folder, trigger_pattern, added_at, container_config,
+          requires_trigger, is_main, group_type, thread_defaults
+        )
+        SELECT
+          jid, name, folder, trigger_pattern, added_at, container_config,
+          requires_trigger, is_main, group_type, thread_defaults
+        FROM registered_groups_old;
+        DROP TABLE registered_groups_old;
+      `);
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Failed to migrate registered_groups folder uniqueness');
   }
 
   // channel および is_group カラムが存在しない場合は追加（既存 DB のマイグレーション）
@@ -654,9 +820,7 @@ export function getRegisteredGroup(
     folder: row.folder,
     trigger: row.trigger_pattern,
     added_at: row.added_at,
-    containerConfig: row.container_config
-      ? JSON.parse(row.container_config)
-      : undefined,
+    containerConfig: _parseContainerConfigJson(row.container_config, row.jid),
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     type: groupType,
@@ -678,8 +842,18 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   }
   const groupType = VALID_GROUP_TYPES.has(rawType) ? rawType : 'chat';
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type, thread_defaults)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type, thread_defaults)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(jid) DO UPDATE SET
+       name = excluded.name,
+       folder = excluded.folder,
+       trigger_pattern = excluded.trigger_pattern,
+       added_at = excluded.added_at,
+       container_config = excluded.container_config,
+       requires_trigger = excluded.requires_trigger,
+       is_main = excluded.is_main,
+       group_type = excluded.group_type,
+       thread_defaults = excluded.thread_defaults`,
   ).run(
     jid,
     group.name,
@@ -722,9 +896,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       folder: row.folder,
       trigger: row.trigger_pattern,
       added_at: row.added_at,
-      containerConfig: row.container_config
-        ? JSON.parse(row.container_config)
-        : undefined,
+      containerConfig: _parseContainerConfigJson(row.container_config, row.jid),
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
       type: groupType,

--- a/src/db.ts
+++ b/src/db.ts
@@ -36,6 +36,22 @@ function parseGroupType(
   return 'chat';
 }
 
+export function _parseThreadDefaultsJson(
+  threadDefaults: string | null,
+  jid: string,
+): ThreadDefaults | undefined {
+  if (!threadDefaults) return undefined;
+  try {
+    return JSON.parse(threadDefaults) as ThreadDefaults;
+  } catch (err) {
+    logger.warn(
+      { jid, err },
+      'Invalid thread_defaults JSON in DB; ignoring this value',
+    );
+    return undefined;
+  }
+}
+
 let db: Database.Database;
 
 function createSchema(database: Database.Database): void {
@@ -644,9 +660,7 @@ export function getRegisteredGroup(
     requiresTrigger:
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     type: groupType,
-    thread_defaults: row.thread_defaults
-      ? (JSON.parse(row.thread_defaults) as ThreadDefaults)
-      : undefined,
+    thread_defaults: _parseThreadDefaultsJson(row.thread_defaults, row.jid),
   };
 }
 
@@ -714,9 +728,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       requiresTrigger:
         row.requires_trigger === null ? undefined : row.requires_trigger === 1,
       type: groupType,
-      thread_defaults: row.thread_defaults
-        ? (JSON.parse(row.thread_defaults) as ThreadDefaults)
-        : undefined,
+      thread_defaults: _parseThreadDefaultsJson(row.thread_defaults, row.jid),
     };
   }
   return result;

--- a/src/db.ts
+++ b/src/db.ts
@@ -40,7 +40,9 @@ function parseGroupType(
 export function _sanitizeContainerConfig(
   raw: unknown,
   jid: string,
-  field: 'container_config' | 'thread_defaults.containerConfig' = 'container_config',
+  field:
+    | 'container_config'
+    | 'thread_defaults.containerConfig' = 'container_config',
 ): ContainerConfig | undefined {
   if (raw == null) return undefined;
   if (typeof raw !== 'object' || Array.isArray(raw)) {
@@ -67,7 +69,9 @@ export function _sanitizeContainerConfig(
     if (Array.isArray(src.additionalMounts)) {
       const mounts = src.additionalMounts
         .filter(
-          (m): m is {
+          (
+            m,
+          ): m is {
             hostPath: string;
             containerPath?: string;
             readonly?: boolean;
@@ -361,7 +365,10 @@ function createSchema(database: Database.Database): void {
       `);
     }
   } catch (err) {
-    logger.warn({ err }, 'Failed to migrate registered_groups folder uniqueness');
+    logger.warn(
+      { err },
+      'Failed to migrate registered_groups folder uniqueness',
+    );
   }
 
   // channel および is_group カラムが存在しない場合は追加（既存 DB のマイグレーション）

--- a/src/db.ts
+++ b/src/db.ts
@@ -46,7 +46,7 @@ export function _sanitizeContainerConfig(
 ): ContainerConfig | undefined {
   if (raw == null) return undefined;
   if (typeof raw !== 'object' || Array.isArray(raw)) {
-    logger.warn({ jid, field }, 'Invalid containerConfig in DB; ignoring');
+    logger.warn({ jid, field }, 'Invalid containerConfig; ignoring');
     return undefined;
   }
   const src = raw as Record<string, unknown>;
@@ -61,7 +61,7 @@ export function _sanitizeContainerConfig(
     } else {
       logger.warn(
         { jid, field, timeout: src.timeout },
-        'Invalid containerConfig.timeout in DB; ignoring',
+        'Invalid containerConfig.timeout; ignoring',
       );
     }
   }
@@ -97,13 +97,13 @@ export function _sanitizeContainerConfig(
       } else if (src.additionalMounts.length > 0) {
         logger.warn(
           { jid, field },
-          'Invalid containerConfig.additionalMounts in DB; ignoring',
+          'Invalid containerConfig.additionalMounts; ignoring',
         );
       }
     } else {
       logger.warn(
         { jid, field },
-        'Invalid containerConfig.additionalMounts in DB; ignoring',
+        'Invalid containerConfig.additionalMounts; ignoring',
       );
     }
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -37,6 +37,14 @@ function parseGroupType(
   return 'chat';
 }
 
+const JID_PREFIX_RE = /^[a-z]{2,}:/;
+
+export function _shouldMigrateSessionKey(key: string): boolean {
+  if (JID_PREFIX_RE.test(key)) return true;
+  if (key.includes('@')) return true;
+  return !isValidGroupFolder(key);
+}
+
 export function _sanitizeContainerConfig(
   raw: unknown,
   jid: string,
@@ -958,16 +966,15 @@ function migrateJsonState(): void {
   }
 
   // sessions.json のマイグレーション
-  // sessions テーブルのキーは group_jid（例: dc:123、tg:456）。
-  // 旧形式はフォルダ名がキーだったため、JID 形式のエントリのみ移行する。
-  const JID_PREFIX_RE = /^[a-z]{2,}:/;
+  // sessions テーブルのキーは group_jid（例: dc:123、tg:456、xxx@g.us）。
+  // 旧形式の folder キーは移行対象から除外する。
   const sessions = migrateFile('sessions.json') as Record<
     string,
     string
   > | null;
   if (sessions) {
     for (const [key, sessionId] of Object.entries(sessions)) {
-      if (JID_PREFIX_RE.test(key)) {
+      if (_shouldMigrateSessionKey(key)) {
         setSession(key, sessionId);
       }
     }

--- a/src/db.ts
+++ b/src/db.ts
@@ -38,11 +38,12 @@ function parseGroupType(
 }
 
 const JID_PREFIX_RE = /^[a-z]{2,}:/;
+const WHATSAPP_JID_RE = /^[^@\s]+@(g\.us|s\.whatsapp\.net)$/;
 
 export function _shouldMigrateSessionKey(key: string): boolean {
   if (JID_PREFIX_RE.test(key)) return true;
-  if (key.includes('@')) return true;
-  return !isValidGroupFolder(key);
+  if (WHATSAPP_JID_RE.test(key)) return true;
+  return false;
 }
 
 export function _sanitizeContainerConfig(

--- a/src/db.ts
+++ b/src/db.ts
@@ -333,7 +333,9 @@ function createSchema(database: Database.Database): void {
   // 旧スキーマ: registered_groups.folder UNIQUE を解除する
   // thread は parent と同じ folder を共有するため、folder の一意制約は不適切。
   try {
-    const indexes = database.prepare(`PRAGMA index_list('registered_groups')`).all() as Array<{
+    const indexes = database
+      .prepare(`PRAGMA index_list('registered_groups')`)
+      .all() as Array<{
       name: string;
       unique: number;
     }>;

--- a/src/group-folder.test.ts
+++ b/src/group-folder.test.ts
@@ -3,9 +3,12 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  decodeIpcNamespaceKey,
+  encodeIpcNamespaceKey,
   isValidGroupFolder,
   resolveGroupFolderPath,
   resolveGroupIpcPath,
+  resolveGroupIpcPathByJid,
 } from './group-folder.js';
 
 describe('group folder validation', () => {
@@ -36,8 +39,31 @@ describe('group folder validation', () => {
     ).toBe(true);
   });
 
+  it('encodes and decodes IPC namespace keys for chat JIDs', () => {
+    const encoded = encodeIpcNamespaceKey('dc:1234567890');
+    expect(encoded).toBe('dc%3A1234567890');
+    expect(decodeIpcNamespaceKey(encoded)).toBe('dc:1234567890');
+  });
+
+  it('resolves safe IPC paths for chat JIDs', () => {
+    const resolved = resolveGroupIpcPathByJid('dc:1234567890');
+    expect(
+      resolved.endsWith(
+        `${path.sep}data${path.sep}ipc${path.sep}dc%3A1234567890`,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns null for invalid encoded IPC namespace keys', () => {
+    expect(decodeIpcNamespaceKey('%E0%A4%A')).toBeNull();
+  });
+
   it('throws for unsafe folder names', () => {
     expect(() => resolveGroupFolderPath('../../etc')).toThrow();
     expect(() => resolveGroupIpcPath('/tmp')).toThrow();
+  });
+
+  it('throws for invalid chat JID IPC namespace keys', () => {
+    expect(() => encodeIpcNamespaceKey('')).toThrow();
   });
 });

--- a/src/group-folder.test.ts
+++ b/src/group-folder.test.ts
@@ -65,5 +65,9 @@ describe('group folder validation', () => {
 
   it('throws for invalid chat JID IPC namespace keys', () => {
     expect(() => encodeIpcNamespaceKey('')).toThrow();
+    expect(() => encodeIpcNamespaceKey('.')).toThrow();
+    expect(() => encodeIpcNamespaceKey('..')).toThrow();
+    expect(() => encodeIpcNamespaceKey('errors')).toThrow();
+    expect(() => resolveGroupIpcPathByJid('.')).toThrow();
   });
 });

--- a/src/group-folder.ts
+++ b/src/group-folder.ts
@@ -28,6 +28,18 @@ function ensureWithinBase(baseDir: string, resolvedPath: string): void {
   }
 }
 
+function assertValidIpcNamespaceKey(key: string): void {
+  if (!key) {
+    throw new Error('IPC namespace key must not be empty');
+  }
+  if (key !== key.trim()) {
+    throw new Error('IPC namespace key must not include surrounding spaces');
+  }
+  if (key.includes('\0')) {
+    throw new Error('IPC namespace key must not include NUL bytes');
+  }
+}
+
 export function resolveGroupFolderPath(folder: string): string {
   assertValidGroupFolder(folder);
   const groupPath = path.resolve(GROUPS_DIR, folder);
@@ -39,6 +51,41 @@ export function resolveGroupIpcPath(folder: string): string {
   assertValidGroupFolder(folder);
   const ipcBaseDir = path.resolve(DATA_DIR, 'ipc');
   const ipcPath = path.resolve(ipcBaseDir, folder);
+  ensureWithinBase(ipcBaseDir, ipcPath);
+  return ipcPath;
+}
+
+/**
+ * IPC ネームスペース用に chat JID をエンコードします。
+ * 例: dc:123 -> dc%3A123
+ */
+export function encodeIpcNamespaceKey(groupJid: string): string {
+  assertValidIpcNamespaceKey(groupJid);
+  return encodeURIComponent(groupJid);
+}
+
+/**
+ * IPC ネームスペース名を chat JID にデコードします。
+ * 無効な値は null を返します。
+ */
+export function decodeIpcNamespaceKey(namespace: string): string | null {
+  if (!namespace || namespace !== namespace.trim()) return null;
+  try {
+    const decoded = decodeURIComponent(namespace);
+    assertValidIpcNamespaceKey(decoded);
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * chat JID 単位の IPC ディレクトリを安全に解決します。
+ */
+export function resolveGroupIpcPathByJid(groupJid: string): string {
+  const namespace = encodeIpcNamespaceKey(groupJid);
+  const ipcBaseDir = path.resolve(DATA_DIR, 'ipc');
+  const ipcPath = path.resolve(ipcBaseDir, namespace);
   ensureWithinBase(ipcBaseDir, ipcPath);
   return ipcPath;
 }

--- a/src/group-folder.ts
+++ b/src/group-folder.ts
@@ -38,6 +38,12 @@ function assertValidIpcNamespaceKey(key: string): void {
   if (key.includes('\0')) {
     throw new Error('IPC namespace key must not include NUL bytes');
   }
+  if (key === '.' || key === '..') {
+    throw new Error('IPC namespace key must not be a dot path segment');
+  }
+  if (key.toLowerCase() === 'errors') {
+    throw new Error('IPC namespace key must not use reserved namespace');
+  }
 }
 
 export function resolveGroupFolderPath(folder: string): string {

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -297,13 +297,8 @@ describe('GroupQueue', () => {
     queue.enqueueMessageCheck('group1@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // Register a process so closeStdin has a groupFolder
-    queue.registerProcess(
-      'group1@g.us',
-      {} as any,
-      'container-1',
-      'test-group',
-    );
+    // Register a process so closeStdin has an active container context
+    queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
     // Enqueue a task while container is active but NOT idle
     const taskFn = vi.fn(async () => {});
@@ -338,12 +333,7 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
 
     // Register process and mark idle
-    queue.registerProcess(
-      'group1@g.us',
-      {} as any,
-      'container-1',
-      'test-group',
-    );
+    queue.registerProcess('group1@g.us', {} as any, 'container-1');
     queue.notifyIdle('group1@g.us');
 
     // Clear previous writes, then enqueue a task
@@ -377,12 +367,7 @@ describe('GroupQueue', () => {
     queue.setProcessMessagesFn(processMessages);
     queue.enqueueMessageCheck('group1@g.us');
     await vi.advanceTimersByTimeAsync(10);
-    queue.registerProcess(
-      'group1@g.us',
-      {} as any,
-      'container-1',
-      'test-group',
-    );
+    queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
     // Container becomes idle
     queue.notifyIdle('group1@g.us');
@@ -418,12 +403,7 @@ describe('GroupQueue', () => {
     // Start a task (sets isTaskContainer = true)
     queue.enqueueTask('group1@g.us', 'task-1', taskFn);
     await vi.advanceTimersByTimeAsync(10);
-    queue.registerProcess(
-      'group1@g.us',
-      {} as any,
-      'container-1',
-      'test-group',
-    );
+    queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
     // sendMessage should return false — user messages must not go to task containers
     const result = queue.sendMessage('group1@g.us', 'hello');
@@ -451,12 +431,7 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
 
     // Register process and enqueue a task (no idle yet — no preemption)
-    queue.registerProcess(
-      'group1@g.us',
-      {} as any,
-      'container-1',
-      'test-group',
-    );
+    queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
     const writeFileSync = vi.mocked(fs.default.writeFileSync);
     writeFileSync.mockClear();

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -159,8 +159,8 @@ export class GroupQueue {
     if (!state.active || state.isTaskContainer) return false;
     state.idleWaiting = false; // エージェントが作業を受け取ろうとしているため、アイドル状態ではなくなる
 
-    const inputDir = path.join(resolveGroupIpcPathByJid(groupJid), 'input');
     try {
+      const inputDir = path.join(resolveGroupIpcPathByJid(groupJid), 'input');
       fs.mkdirSync(inputDir, { recursive: true });
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`;
       const filepath = path.join(inputDir, filename);

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -180,8 +180,8 @@ export class GroupQueue {
     const state = this.getGroup(groupJid);
     if (!state.active) return;
 
-    const inputDir = path.join(resolveGroupIpcPathByJid(groupJid), 'input');
     try {
+      const inputDir = path.join(resolveGroupIpcPathByJid(groupJid), 'input');
       fs.mkdirSync(inputDir, { recursive: true });
       fs.writeFileSync(path.join(inputDir, '_close'), '');
     } catch {

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -2,7 +2,8 @@ import { ChildProcess } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import { DATA_DIR, MAX_CONCURRENT_CONTAINERS } from './config.js';
+import { MAX_CONCURRENT_CONTAINERS } from './config.js';
+import { resolveGroupIpcPathByJid } from './group-folder.js';
 import { logger } from './logger.js';
 
 interface QueuedTask {
@@ -23,7 +24,6 @@ interface GroupState {
   pendingTasks: QueuedTask[];
   process: ChildProcess | null;
   containerName: string | null;
-  groupFolder: string | null;
   retryCount: number;
 }
 
@@ -47,7 +47,6 @@ export class GroupQueue {
         pendingTasks: [],
         process: null,
         containerName: null,
-        groupFolder: null,
         retryCount: 0,
       };
       this.groups.set(groupJid, state);
@@ -133,12 +132,10 @@ export class GroupQueue {
     groupJid: string,
     proc: ChildProcess,
     containerName: string,
-    groupFolder?: string,
   ): void {
     const state = this.getGroup(groupJid);
     state.process = proc;
     state.containerName = containerName;
-    if (groupFolder) state.groupFolder = groupFolder;
   }
 
   /**
@@ -159,11 +156,10 @@ export class GroupQueue {
    */
   sendMessage(groupJid: string, text: string): boolean {
     const state = this.getGroup(groupJid);
-    if (!state.active || !state.groupFolder || state.isTaskContainer)
-      return false;
+    if (!state.active || state.isTaskContainer) return false;
     state.idleWaiting = false; // エージェントが作業を受け取ろうとしているため、アイドル状態ではなくなる
 
-    const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
+    const inputDir = path.join(resolveGroupIpcPathByJid(groupJid), 'input');
     try {
       fs.mkdirSync(inputDir, { recursive: true });
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`;
@@ -182,9 +178,9 @@ export class GroupQueue {
    */
   closeStdin(groupJid: string): void {
     const state = this.getGroup(groupJid);
-    if (!state.active || !state.groupFolder) return;
+    if (!state.active) return;
 
-    const inputDir = path.join(DATA_DIR, 'ipc', state.groupFolder, 'input');
+    const inputDir = path.join(resolveGroupIpcPathByJid(groupJid), 'input');
     try {
       fs.mkdirSync(inputDir, { recursive: true });
       fs.writeFileSync(path.join(inputDir, '_close'), '');
@@ -225,7 +221,6 @@ export class GroupQueue {
       state.active = false;
       state.process = null;
       state.containerName = null;
-      state.groupFolder = null;
       this.activeCount--;
       this.drainGroup(groupJid);
     }
@@ -254,7 +249,6 @@ export class GroupQueue {
       state.runningTaskId = null;
       state.process = null;
       state.containerName = null;
-      state.groupFolder = null;
       this.activeCount--;
       this.drainGroup(groupJid);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ function registerGroup(jid: string, group: RegisteredGroup): void {
 
 /**
  * thread message を受信したとき、parent group の thread_defaults に基づいて
- * 子 group を自動登録する。登録できた場合は true を返す。
+ * 子 group を自動登録する。
  */
 function autoRegisterThread(
   chatJid: string,
@@ -178,6 +178,9 @@ export function _setRegisteredGroups(
 ): void {
   registeredGroups = groups;
 }
+
+/** @internal - テスト用にエクスポート */
+export const _autoRegisterThread = autoRegisterThread;
 
 /**
  * グループのすべての保留中メッセージを処理します。

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ function autoRegisterThread(
     added_at: new Date().toISOString(),
     containerConfig: td.containerConfig ?? parent.containerConfig,
     requiresTrigger: td.requiresTrigger ?? parent.requiresTrigger,
-    type: td.type ?? 'thread',
+    type: 'thread',
   };
   registerGroup(chatJid, childGroup);
   logger.info(

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ function autoRegisterThread(
     added_at: new Date().toISOString(),
     containerConfig: td.containerConfig ?? parent.containerConfig,
     requiresTrigger: td.requiresTrigger ?? parent.requiresTrigger,
-    type: 'thread',
+    type: td.type ?? 'thread',
   };
   registerGroup(chatJid, childGroup);
   logger.info(

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,9 +136,10 @@ function autoRegisterThread(
 ): void {
   const td = parent.thread_defaults!;
   const requestedType = td.type;
-  const childType = requestedType === 'chat' || requestedType === 'thread'
-    ? requestedType
-    : 'thread';
+  const childType =
+    requestedType === 'chat' || requestedType === 'thread'
+      ? requestedType
+      : 'thread';
   if (requestedType && childType !== requestedType) {
     logger.warn(
       { chatJid, requestedType },

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,10 +327,11 @@ async function runAgent(
   // コンテナが読み取るためのタスクスナップショットを更新（グループでフィルタリング）
   const tasks = getAllTasks();
   writeTasksSnapshot(
-    group.folder,
+    chatJid,
     isPrivileged,
     tasks.map((t) => ({
       id: t.id,
+      groupJid: t.chat_jid,
       groupFolder: t.group_folder,
       prompt: t.prompt,
       schedule_type: t.schedule_type,
@@ -342,7 +343,7 @@ async function runAgent(
 
   // 利用可能なグループのスナップショットを更新（特権グループのみが全グループを表示可能）
   const availableGroups = getAvailableGroups();
-  writeGroupsSnapshot(group.folder, isPrivileged, availableGroups);
+  writeGroupsSnapshot(chatJid, isPrivileged, availableGroups);
 
   // ストリームされた結果からセッション ID を追跡するために onOutput をラップ
   const wrappedOnOutput = onOutput
@@ -367,7 +368,7 @@ async function runAgent(
         assistantName: ASSISTANT_NAME,
       },
       (proc, containerName) =>
-        queue.registerProcess(chatJid, proc, containerName, group.folder),
+        queue.registerProcess(chatJid, proc, containerName),
       wrappedOnOutput,
     );
 
@@ -659,8 +660,8 @@ async function main(): Promise<void> {
     registeredGroups: () => registeredGroups,
     getSessions: () => sessions,
     queue,
-    onProcess: (groupJid, proc, containerName, groupFolder) =>
-      queue.registerProcess(groupJid, proc, containerName, groupFolder),
+    onProcess: (groupJid, proc, containerName) =>
+      queue.registerProcess(groupJid, proc, containerName),
     sendMessage: async (jid, rawText) => {
       const channel = findChannel(channels, jid);
       if (!channel) {
@@ -687,7 +688,7 @@ async function main(): Promise<void> {
       );
     },
     getAvailableGroups,
-    writeGroupsSnapshot: (gf, im, ag) => writeGroupsSnapshot(gf, im, ag),
+    writeGroupsSnapshot: (gj, im, ag) => writeGroupsSnapshot(gj, im, ag),
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,12 @@ import {
 } from './sender-allowlist.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { hasPrivilege, resolveGroupType } from './group-type.js';
-import { Channel, InboundMessage, NewMessage, RegisteredGroup } from './types.js';
+import {
+  Channel,
+  InboundMessage,
+  NewMessage,
+  RegisteredGroup,
+} from './types.js';
 import { logger } from './logger.js';
 
 // リファクタリング中の後方互換性のために再エクスポート
@@ -130,8 +135,9 @@ function autoRegisterThread(
   parent: RegisteredGroup,
 ): void {
   const td = parent.thread_defaults!;
-  const threadName =
-    msg.sender_name ? `Thread (from ${msg.sender_name})` : 'Thread';
+  const threadName = msg.sender_name
+    ? `Thread (from ${msg.sender_name})`
+    : 'Thread';
   const childGroup: RegisteredGroup = {
     name: threadName,
     folder: parent.folder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -599,7 +599,11 @@ async function main(): Promise<void> {
         const parent = registeredGroups[msg.parent_jid];
         if (parent?.thread_defaults) {
           autoRegisterThread(chatJid, msg, parent);
-          // 登録したので以降の storeMessage / allowlist 処理を通常通り実行する
+          if (!registeredGroups[chatJid]) {
+            // registerGroup() が内部で早期 return した場合は未登録のままなので保存しない
+            return;
+          }
+          // 登録成功時のみ以降の storeMessage / allowlist 処理を通常通り実行する
         } else {
           // parent が thread_defaults を持たない — discord.ts がすでにフィルタしているが念のため
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ import {
 } from './sender-allowlist.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { hasPrivilege, resolveGroupType } from './group-type.js';
-import { Channel, NewMessage, RegisteredGroup } from './types.js';
+import { Channel, InboundMessage, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
 
 // リファクタリング中の後方互換性のために再エクスポート
@@ -117,6 +117,34 @@ function registerGroup(jid: string, group: RegisteredGroup): void {
   logger.info(
     { jid, name: group.name, folder: group.folder },
     'Group registered',
+  );
+}
+
+/**
+ * thread message を受信したとき、parent group の thread_defaults に基づいて
+ * 子 group を自動登録する。登録できた場合は true を返す。
+ */
+function autoRegisterThread(
+  chatJid: string,
+  msg: InboundMessage,
+  parent: RegisteredGroup,
+): void {
+  const td = parent.thread_defaults!;
+  const threadName =
+    msg.sender_name ? `Thread (from ${msg.sender_name})` : 'Thread';
+  const childGroup: RegisteredGroup = {
+    name: threadName,
+    folder: parent.folder,
+    trigger: parent.trigger,
+    added_at: new Date().toISOString(),
+    containerConfig: td.containerConfig ?? parent.containerConfig,
+    requiresTrigger: td.requiresTrigger ?? parent.requiresTrigger,
+    type: td.type ?? 'thread',
+  };
+  registerGroup(chatJid, childGroup);
+  logger.info(
+    { chatJid, parentFolder: parent.folder, type: childGroup.type },
+    'Thread group auto-registered',
   );
 }
 
@@ -274,7 +302,7 @@ async function runAgent(
 ): Promise<'success' | 'error'> {
   const groupType = resolveGroupType(group);
   const isPrivileged = groupType === 'main' || groupType === 'override';
-  const sessionId = sessions[group.folder];
+  const sessionId = sessions[chatJid];
 
   // コンテナが読み取るためのタスクスナップショットを更新（グループでフィルタリング）
   const tasks = getAllTasks();
@@ -300,8 +328,8 @@ async function runAgent(
   const wrappedOnOutput = onOutput
     ? async (output: ContainerOutput) => {
         if (output.newSessionId) {
-          sessions[group.folder] = output.newSessionId;
-          setSession(group.folder, output.newSessionId);
+          sessions[chatJid] = output.newSessionId;
+          setSession(chatJid, output.newSessionId);
         }
         await onOutput(output);
       }
@@ -324,8 +352,8 @@ async function runAgent(
     );
 
     if (output.newSessionId) {
-      sessions[group.folder] = output.newSessionId;
-      setSession(group.folder, output.newSessionId);
+      sessions[chatJid] = output.newSessionId;
+      setSession(chatJid, output.newSessionId);
     }
 
     if (output.status === 'error') {
@@ -535,7 +563,7 @@ async function main(): Promise<void> {
 
   // チャネルコールバック（すべてのチャネルで共有）
   const channelOpts = {
-    onMessage: (chatJid: string, msg: NewMessage) => {
+    onMessage: (chatJid: string, msg: InboundMessage) => {
       // リモートコントロールコマンド — 保存前にインターセプト
       const trimmed = msg.content.trim();
       if (trimmed === '/remote-control' || trimmed === '/remote-control-end') {
@@ -543,6 +571,18 @@ async function main(): Promise<void> {
           logger.error({ err, chatJid }, 'Remote control command error'),
         );
         return;
+      }
+
+      // thread 自動登録 — まだ未登録で parent_jid がある場合のみ試みる
+      if (!registeredGroups[chatJid] && msg.parent_jid) {
+        const parent = registeredGroups[msg.parent_jid];
+        if (parent?.thread_defaults) {
+          autoRegisterThread(chatJid, msg, parent);
+          // 登録したので以降の storeMessage / allowlist 処理を通常通り実行する
+        } else {
+          // parent が thread_defaults を持たない — discord.ts がすでにフィルタしているが念のため
+          return;
+        }
       }
 
       // 送信者許可リストのドロップモード: 保存前に拒否された送信者からのメッセージを破棄

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,16 @@ function autoRegisterThread(
   parent: RegisteredGroup,
 ): void {
   const td = parent.thread_defaults!;
+  const requestedType = td.type;
+  const childType = requestedType === 'chat' || requestedType === 'thread'
+    ? requestedType
+    : 'thread';
+  if (requestedType && childType !== requestedType) {
+    logger.warn(
+      { chatJid, requestedType },
+      'Invalid or privileged thread_defaults.type detected at runtime; falling back to thread',
+    );
+  }
   const threadName = msg.sender_name
     ? `Thread (from ${msg.sender_name})`
     : 'Thread';
@@ -145,7 +155,7 @@ function autoRegisterThread(
     added_at: new Date().toISOString(),
     containerConfig: td.containerConfig ?? parent.containerConfig,
     requiresTrigger: td.requiresTrigger ?? parent.requiresTrigger,
-    type: td.type ?? 'thread',
+    type: childType,
   };
   registerGroup(chatJid, childGroup);
   logger.info(

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -726,6 +726,30 @@ describe('register_group group_type', () => {
     const allGroups = getAllRegisteredGroups();
     expect(allGroups['bad-thread-defaults@g.us']).toBeUndefined();
   });
+
+  it('thread_defaults.containerConfig.timeout が不正な場合は拒否される', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'bad-thread-cc@g.us',
+        name: 'Bad Thread CC',
+        folder: 'bad-thread-cc',
+        trigger: '@Andy',
+        thread_defaults: {
+          type: 'thread',
+          containerConfig: {
+            timeout: 'abc' as unknown as number,
+          },
+        },
+      },
+      'main@g.us',
+      true,
+      deps,
+    );
+
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['bad-thread-cc@g.us']).toBeUndefined();
+  });
 });
 
 describe('update_group group_type', () => {

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -382,6 +382,26 @@ describe('refresh_groups authorization', () => {
 // The logic: isPrivileged || targetChatJid === sourceChatJid
 
 describe('IPC message authorization', () => {
+  function isValidMessagePayload(data: unknown): data is {
+    type: 'message';
+    chatJid: string;
+    text: string;
+  } {
+    if (!data || typeof data !== 'object') return false;
+    const payload = data as {
+      type?: unknown;
+      chatJid?: unknown;
+      text?: unknown;
+    };
+    return (
+      payload.type === 'message' &&
+      typeof payload.chatJid === 'string' &&
+      typeof payload.text === 'string' &&
+      payload.chatJid.length > 0 &&
+      payload.text.length > 0
+    );
+  }
+
   // Replicate the exact check from the IPC watcher
   function isMessageAuthorized(
     sourceChatJid: string,
@@ -414,6 +434,46 @@ describe('IPC message authorization', () => {
   it('main group can send to unregistered JID', () => {
     // Main is always authorized regardless of target
     expect(isMessageAuthorized('main@g.us', true, 'unknown@g.us')).toBe(true);
+  });
+
+  it('rejects message payload when chatJid is not a string', () => {
+    expect(
+      isValidMessagePayload({
+        type: 'message',
+        chatJid: 123,
+        text: 'hello',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects message payload when text is not a string', () => {
+    expect(
+      isValidMessagePayload({
+        type: 'message',
+        chatJid: 'other@g.us',
+        text: { value: 'hello' },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects message payload when chatJid is an empty string', () => {
+    expect(
+      isValidMessagePayload({
+        type: 'message',
+        chatJid: '',
+        text: 'hello',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects message payload when text is an empty string', () => {
+    expect(
+      isValidMessagePayload({
+        type: 'message',
+        chatJid: 'other@g.us',
+        text: '',
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -723,6 +723,28 @@ describe('register_group group_type', () => {
     const allGroups = getAllRegisteredGroups();
     expect(allGroups['override@g.us']).toBeUndefined();
   });
+
+  it('thread_defaults.requiresTrigger が boolean でない場合は拒否される', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'bad-thread-defaults@g.us',
+        name: 'Bad Thread Defaults',
+        folder: 'bad-thread-defaults',
+        trigger: '@Andy',
+        thread_defaults: {
+          type: 'thread',
+          requiresTrigger: 'nope' as unknown as boolean,
+        },
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['bad-thread-defaults@g.us']).toBeUndefined();
+  });
 });
 
 describe('update_group group_type', () => {
@@ -830,5 +852,54 @@ describe('update_group group_type', () => {
     const allGroups = getAllRegisteredGroups();
     expect(allGroups['protected@g.us']).toBeDefined();
     expect(allGroups['protected@g.us'].type).toBe('chat');
+  });
+
+  it('update_group で thread_defaults を更新・クリアできる', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'threadcfg@g.us',
+        name: 'Thread Cfg Group',
+        folder: 'threadcfg-group',
+        trigger: '@Andy',
+        group_type: 'chat',
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    await processTaskIpc(
+      {
+        type: 'update_group',
+        jid: 'threadcfg@g.us',
+        thread_defaults: { type: 'chat', requiresTrigger: false },
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    {
+      const allGroups = getAllRegisteredGroups();
+      expect(allGroups['threadcfg@g.us'].thread_defaults).toEqual({
+        type: 'chat',
+        requiresTrigger: false,
+      });
+    }
+
+    await processTaskIpc(
+      {
+        type: 'update_group',
+        jid: 'threadcfg@g.us',
+        thread_defaults: null as unknown as object,
+      },
+      'whatsapp_main',
+      true,
+      deps,
+    );
+
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['threadcfg@g.us'].thread_defaults).toBeUndefined();
   });
 });

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -810,6 +810,29 @@ describe('register_group group_type', () => {
     const allGroups = getAllRegisteredGroups();
     expect(allGroups['bad-thread-cc@g.us']).toBeUndefined();
   });
+
+  it('register_group の containerConfig はサニタイズされる', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'sanitize-cc@g.us',
+        name: 'Sanitized CC',
+        folder: 'sanitized-cc',
+        trigger: '@Andy',
+        containerConfig: {
+          timeout: 'abc' as unknown as number,
+          additionalMounts: 'oops' as unknown as [],
+        },
+      },
+      'main@g.us',
+      true,
+      deps,
+    );
+
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['sanitize-cc@g.us']).toBeDefined();
+    expect(allGroups['sanitize-cc@g.us'].containerConfig).toEqual({});
+  });
 });
 
 describe('update_group group_type', () => {

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -78,7 +78,7 @@ describe('schedule_task authorization', () => {
         schedule_value: '2025-06-01T00:00:00',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -98,7 +98,7 @@ describe('schedule_task authorization', () => {
         schedule_value: '2025-06-01T00:00:00',
         targetJid: 'other@g.us',
       },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -117,7 +117,7 @@ describe('schedule_task authorization', () => {
         schedule_value: '2025-06-01T00:00:00',
         targetJid: 'main@g.us',
       },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -135,7 +135,7 @@ describe('schedule_task authorization', () => {
         schedule_value: '2025-06-01T00:00:00',
         targetJid: 'unknown@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -178,7 +178,7 @@ describe('pause_task authorization', () => {
   it('main group can pause any task', async () => {
     await processTaskIpc(
       { type: 'pause_task', taskId: 'task-other' },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -188,7 +188,7 @@ describe('pause_task authorization', () => {
   it('non-main group can pause its own task', async () => {
     await processTaskIpc(
       { type: 'pause_task', taskId: 'task-other' },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -198,7 +198,7 @@ describe('pause_task authorization', () => {
   it('non-main group cannot pause another groups task', async () => {
     await processTaskIpc(
       { type: 'pause_task', taskId: 'task-main' },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -227,7 +227,7 @@ describe('resume_task authorization', () => {
   it('main group can resume any task', async () => {
     await processTaskIpc(
       { type: 'resume_task', taskId: 'task-paused' },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -237,7 +237,7 @@ describe('resume_task authorization', () => {
   it('non-main group can resume its own task', async () => {
     await processTaskIpc(
       { type: 'resume_task', taskId: 'task-paused' },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -247,7 +247,7 @@ describe('resume_task authorization', () => {
   it('non-main group cannot resume another groups task', async () => {
     await processTaskIpc(
       { type: 'resume_task', taskId: 'task-paused' },
-      'third-group',
+      'third@g.us',
       false,
       deps,
     );
@@ -274,7 +274,7 @@ describe('cancel_task authorization', () => {
 
     await processTaskIpc(
       { type: 'cancel_task', taskId: 'task-to-cancel' },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -297,7 +297,7 @@ describe('cancel_task authorization', () => {
 
     await processTaskIpc(
       { type: 'cancel_task', taskId: 'task-own' },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -320,7 +320,7 @@ describe('cancel_task authorization', () => {
 
     await processTaskIpc(
       { type: 'cancel_task', taskId: 'task-foreign' },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -340,7 +340,7 @@ describe('register_group authorization', () => {
         folder: 'new-group',
         trigger: '@Andy',
       },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -358,7 +358,7 @@ describe('register_group authorization', () => {
         folder: '../../outside',
         trigger: '@Andy',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -372,67 +372,48 @@ describe('register_group authorization', () => {
 describe('refresh_groups authorization', () => {
   it('non-main group cannot trigger refresh', async () => {
     // This should be silently blocked (no crash, no effect)
-    await processTaskIpc(
-      { type: 'refresh_groups' },
-      'other-group',
-      false,
-      deps,
-    );
+    await processTaskIpc({ type: 'refresh_groups' }, 'other@g.us', false, deps);
     // If we got here without error, the auth gate worked
   });
 });
 
 // --- IPC message authorization ---
 // Tests the authorization pattern from startIpcWatcher (ipc.ts).
-// The logic: isMain || (targetGroup && targetGroup.folder === sourceGroup)
+// The logic: isPrivileged || targetChatJid === sourceChatJid
 
 describe('IPC message authorization', () => {
   // Replicate the exact check from the IPC watcher
   function isMessageAuthorized(
-    sourceGroup: string,
-    isMain: boolean,
+    sourceChatJid: string,
+    isPrivileged: boolean,
     targetChatJid: string,
-    registeredGroups: Record<string, RegisteredGroup>,
   ): boolean {
-    const targetGroup = registeredGroups[targetChatJid];
-    return isMain || (!!targetGroup && targetGroup.folder === sourceGroup);
+    return isPrivileged || targetChatJid === sourceChatJid;
   }
 
   it('main group can send to any group', () => {
-    expect(
-      isMessageAuthorized('whatsapp_main', true, 'other@g.us', groups),
-    ).toBe(true);
-    expect(
-      isMessageAuthorized('whatsapp_main', true, 'third@g.us', groups),
-    ).toBe(true);
+    expect(isMessageAuthorized('main@g.us', true, 'other@g.us')).toBe(true);
+    expect(isMessageAuthorized('main@g.us', true, 'third@g.us')).toBe(true);
   });
 
   it('non-main group can send to its own chat', () => {
-    expect(
-      isMessageAuthorized('other-group', false, 'other@g.us', groups),
-    ).toBe(true);
+    expect(isMessageAuthorized('other@g.us', false, 'other@g.us')).toBe(true);
   });
 
   it('non-main group cannot send to another groups chat', () => {
-    expect(isMessageAuthorized('other-group', false, 'main@g.us', groups)).toBe(
-      false,
-    );
-    expect(
-      isMessageAuthorized('other-group', false, 'third@g.us', groups),
-    ).toBe(false);
+    expect(isMessageAuthorized('other@g.us', false, 'main@g.us')).toBe(false);
+    expect(isMessageAuthorized('other@g.us', false, 'third@g.us')).toBe(false);
   });
 
   it('non-main group cannot send to unregistered JID', () => {
-    expect(
-      isMessageAuthorized('other-group', false, 'unknown@g.us', groups),
-    ).toBe(false);
+    expect(isMessageAuthorized('other@g.us', false, 'unknown@g.us')).toBe(
+      false,
+    );
   });
 
   it('main group can send to unregistered JID', () => {
     // Main is always authorized regardless of target
-    expect(
-      isMessageAuthorized('whatsapp_main', true, 'unknown@g.us', groups),
-    ).toBe(true);
+    expect(isMessageAuthorized('main@g.us', true, 'unknown@g.us')).toBe(true);
   });
 });
 
@@ -448,7 +429,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: '0 9 * * *', // every day at 9am
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -472,7 +453,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: 'not a cron',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -491,7 +472,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: '3600000', // 1 hour
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -514,7 +495,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: 'abc',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -531,7 +512,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: '0',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -548,7 +529,7 @@ describe('schedule_task schedule types', () => {
         schedule_value: 'not-a-date',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -570,7 +551,7 @@ describe('schedule_task context_mode', () => {
         context_mode: 'group',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -589,7 +570,7 @@ describe('schedule_task context_mode', () => {
         context_mode: 'isolated',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -608,7 +589,7 @@ describe('schedule_task context_mode', () => {
         context_mode: 'bogus' as any,
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -626,7 +607,7 @@ describe('schedule_task context_mode', () => {
         schedule_value: '2025-06-01T00:00:00',
         targetJid: 'other@g.us',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -648,7 +629,7 @@ describe('register_group success', () => {
         folder: 'new-group',
         trigger: '@Andy',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -669,7 +650,7 @@ describe('register_group success', () => {
         name: 'Partial',
         // missing folder and trigger
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -692,7 +673,7 @@ describe('register_group group_type', () => {
         trigger: '@Andy',
         group_type: 'chat',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -714,7 +695,7 @@ describe('register_group group_type', () => {
         trigger: '@Andy',
         group_type: 'override',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -737,7 +718,7 @@ describe('register_group group_type', () => {
           requiresTrigger: 'nope' as unknown as boolean,
         },
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -759,7 +740,7 @@ describe('update_group group_type', () => {
         trigger: '@Andy',
         group_type: 'chat',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -775,7 +756,7 @@ describe('update_group group_type', () => {
         jid: 'target@g.us',
         group_type: 'main',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -797,7 +778,7 @@ describe('update_group group_type', () => {
         trigger: '@Andy',
         group_type: 'chat',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -809,7 +790,7 @@ describe('update_group group_type', () => {
         jid: 'noraise@g.us',
         group_type: 'override',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -831,7 +812,7 @@ describe('update_group group_type', () => {
         trigger: '@Andy',
         group_type: 'chat',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -843,7 +824,7 @@ describe('update_group group_type', () => {
         jid: 'protected@g.us',
         group_type: 'main',
       },
-      'other-group',
+      'other@g.us',
       false,
       deps,
     );
@@ -864,7 +845,7 @@ describe('update_group group_type', () => {
         trigger: '@Andy',
         group_type: 'chat',
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -875,7 +856,7 @@ describe('update_group group_type', () => {
         jid: 'threadcfg@g.us',
         thread_defaults: { type: 'chat', requiresTrigger: false },
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );
@@ -894,7 +875,7 @@ describe('update_group group_type', () => {
         jid: 'threadcfg@g.us',
         thread_defaults: null as unknown as object,
       },
-      'whatsapp_main',
+      'main@g.us',
       true,
       deps,
     );

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -9,13 +9,59 @@ import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { hasPrivilege, VALID_GROUP_TYPES } from './group-type.js';
 import { logger } from './logger.js';
-import { GroupType, RegisteredGroup, ThreadDefaults } from './types.js';
+import {
+  GroupType,
+  RegisteredGroup,
+  ThreadDefaultGroupType,
+  ThreadDefaults,
+} from './types.js';
 
 function parseIpcGroupType(value: unknown): GroupType | null {
   if (typeof value === 'string' && VALID_GROUP_TYPES.has(value)) {
     return value as GroupType;
   }
   return null;
+}
+
+const VALID_THREAD_DEFAULT_TYPES: ReadonlySet<string> = new Set([
+  'chat',
+  'thread',
+]);
+
+function parseIpcThreadDefaultType(
+  value: unknown,
+): ThreadDefaultGroupType | null {
+  if (typeof value === 'string' && VALID_THREAD_DEFAULT_TYPES.has(value)) {
+    return value as ThreadDefaultGroupType;
+  }
+  return null;
+}
+
+/**
+ * thread_defaults を IPC 入力から検証して返す。
+ * type が不正または特権値の場合は null を返す。
+ */
+function validateThreadDefaults(
+  raw: unknown,
+  sourceGroup: string,
+): ThreadDefaults | null | false {
+  if (raw == null) return null;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    logger.warn({ sourceGroup }, 'Invalid thread_defaults: not an object');
+    return false;
+  }
+  const td = raw as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(td, 'type')) {
+    const parsedType = parseIpcThreadDefaultType(td.type);
+    if (!parsedType) {
+      logger.warn(
+        { sourceGroup, type: td.type },
+        'Invalid or privileged thread_defaults.type in register_group request',
+      );
+      return false;
+    }
+  }
+  return raw as ThreadDefaults;
 }
 
 export interface IpcDeps {
@@ -456,6 +502,13 @@ export async function processTaskIpc(
           break;
         }
         const groupType = parsedGroupType ?? 'chat';
+        const validatedThreadDefaults = validateThreadDefaults(
+          data.thread_defaults,
+          sourceGroup,
+        );
+        if (validatedThreadDefaults === false) {
+          break;
+        }
         deps.registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
@@ -464,7 +517,7 @@ export async function processTaskIpc(
           containerConfig: data.containerConfig,
           requiresTrigger: data.requiresTrigger,
           type: groupType,
-          thread_defaults: data.thread_defaults,
+          thread_defaults: validatedThreadDefaults ?? undefined,
         });
         logger.info(
           { jid: data.jid, folder: data.folder, groupType, sourceGroup },

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -9,7 +9,7 @@ import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { hasPrivilege, VALID_GROUP_TYPES } from './group-type.js';
 import { logger } from './logger.js';
-import { GroupType, RegisteredGroup } from './types.js';
+import { GroupType, RegisteredGroup, ThreadDefaults } from './types.js';
 
 function parseIpcGroupType(value: unknown): GroupType | null {
   if (typeof value === 'string' && VALID_GROUP_TYPES.has(value)) {
@@ -179,6 +179,7 @@ export async function processTaskIpc(
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
     group_type?: string;
+    thread_defaults?: ThreadDefaults;
   },
   sourceGroup: string, // IPC ディレクトリから検証された識別情報
   isPrivileged: boolean, // main または override の特権を持つか
@@ -463,6 +464,7 @@ export async function processTaskIpc(
           containerConfig: data.containerConfig,
           requiresTrigger: data.requiresTrigger,
           type: groupType,
+          thread_defaults: data.thread_defaults,
         });
         logger.info(
           { jid: data.jid, folder: data.folder, groupType, sourceGroup },

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -39,7 +39,8 @@ function parseIpcThreadDefaultType(
 
 /**
  * thread_defaults を IPC 入力から検証して返す。
- * type が不正または特権値の場合は null を返す。
+ * - 省略（null/undefined）の場合は null を返す（正常）
+ * - オブジェクトでない、または type が不正・特権値の場合は false を返す（リクエストを破棄）
  */
 function validateThreadDefaults(
   raw: unknown,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -579,7 +579,9 @@ export async function processTaskIpc(
           data,
           'group_type',
         );
-        const newType = hasGroupType ? parseIpcGroupType(data.group_type) : null;
+        const newType = hasGroupType
+          ? parseIpcGroupType(data.group_type)
+          : null;
         if (hasGroupType && !newType) {
           logger.warn(
             { sourceGroup, group_type: data.group_type },
@@ -629,10 +631,7 @@ export async function processTaskIpc(
           'Group updated via IPC',
         );
       } else {
-        logger.warn(
-          { data },
-          'Invalid update_group request - missing jid',
-        );
+        logger.warn({ data }, 'Invalid update_group request - missing jid');
       }
       break;
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -601,12 +601,23 @@ export async function processTaskIpc(
         if (validatedThreadDefaults === false) {
           break;
         }
+        const hasContainerConfig = Object.prototype.hasOwnProperty.call(
+          data,
+          'containerConfig',
+        );
+        const sanitizedContainerConfig = hasContainerConfig
+          ? _sanitizeContainerConfig(
+              data.containerConfig,
+              data.jid,
+              'container_config',
+            )
+          : undefined;
         deps.registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
           trigger: data.trigger,
           added_at: new Date().toISOString(),
-          containerConfig: data.containerConfig,
+          containerConfig: sanitizedContainerConfig,
           requiresTrigger: data.requiresTrigger,
           type: groupType,
           thread_defaults: validatedThreadDefaults ?? undefined,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -6,7 +6,11 @@ import { CronExpressionParser } from 'cron-parser';
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
-import { isValidGroupFolder } from './group-folder.js';
+import {
+  decodeIpcNamespaceKey,
+  encodeIpcNamespaceKey,
+  isValidGroupFolder,
+} from './group-folder.js';
 import { hasPrivilege, VALID_GROUP_TYPES } from './group-type.js';
 import { logger } from './logger.js';
 import {
@@ -44,11 +48,11 @@ function parseIpcThreadDefaultType(
  */
 function validateThreadDefaults(
   raw: unknown,
-  sourceGroup: string,
+  sourceChatJid: string,
 ): ThreadDefaults | null | false {
   if (raw == null) return null;
   if (typeof raw !== 'object' || Array.isArray(raw)) {
-    logger.warn({ sourceGroup }, 'Invalid thread_defaults: not an object');
+    logger.warn({ sourceChatJid }, 'Invalid thread_defaults: not an object');
     return false;
   }
   const td = raw as Record<string, unknown>;
@@ -57,7 +61,7 @@ function validateThreadDefaults(
     const parsedType = parseIpcThreadDefaultType(td.type);
     if (!parsedType) {
       logger.warn(
-        { sourceGroup, type: td.type },
+        { sourceChatJid, type: td.type },
         'Invalid or privileged thread_defaults.type in IPC request',
       );
       return false;
@@ -67,7 +71,7 @@ function validateThreadDefaults(
   if (Object.prototype.hasOwnProperty.call(td, 'requiresTrigger')) {
     if (typeof td.requiresTrigger !== 'boolean') {
       logger.warn(
-        { sourceGroup, requiresTrigger: td.requiresTrigger },
+        { sourceChatJid, requiresTrigger: td.requiresTrigger },
         'Invalid thread_defaults.requiresTrigger: must be boolean',
       );
       return false;
@@ -81,7 +85,7 @@ function validateThreadDefaults(
       Array.isArray(td.containerConfig)
     ) {
       logger.warn(
-        { sourceGroup, containerConfig: td.containerConfig },
+        { sourceChatJid, containerConfig: td.containerConfig },
         'Invalid thread_defaults.containerConfig: must be object',
       );
       return false;
@@ -100,7 +104,7 @@ export interface IpcDeps {
   syncGroups: (force: boolean) => Promise<void>;
   getAvailableGroups: () => AvailableGroup[];
   writeGroupsSnapshot: (
-    groupFolder: string,
+    groupJid: string,
     isPrivileged: boolean,
     availableGroups: AvailableGroup[],
   ) => void;
@@ -119,10 +123,10 @@ export function startIpcWatcher(deps: IpcDeps): void {
   fs.mkdirSync(ipcBaseDir, { recursive: true });
 
   const processIpcFiles = async () => {
-    // すべてのグループの IPC ディレクトリをスキャン（ディレクトリ名で識別）
-    let groupFolders: string[];
+    // すべての IPC ネームスペースをスキャン（ディレクトリ名は chatJid のエンコード値）
+    let namespaceDirs: string[];
     try {
-      groupFolders = fs.readdirSync(ipcBaseDir).filter((f) => {
+      namespaceDirs = fs.readdirSync(ipcBaseDir).filter((f) => {
         const stat = fs.statSync(path.join(ipcBaseDir, f));
         return stat.isDirectory() && f !== 'errors';
       });
@@ -134,16 +138,34 @@ export function startIpcWatcher(deps: IpcDeps): void {
 
     const registeredGroups = deps.registeredGroups();
 
-    // 登録済みグループから folder→hasPrivilege のルックアップを構築
-    const folderPrivilege = new Map<string, boolean>();
-    for (const group of Object.values(registeredGroups)) {
-      if (hasPrivilege(group)) folderPrivilege.set(group.folder, true);
-    }
+    for (const namespaceDir of namespaceDirs) {
+      const sourceChatJid = decodeIpcNamespaceKey(namespaceDir);
+      if (!sourceChatJid) {
+        logger.warn({ namespaceDir }, 'Invalid IPC namespace directory');
+        continue;
+      }
 
-    for (const sourceGroup of groupFolders) {
-      const isPrivileged = folderPrivilege.get(sourceGroup) === true;
-      const messagesDir = path.join(ipcBaseDir, sourceGroup, 'messages');
-      const tasksDir = path.join(ipcBaseDir, sourceGroup, 'tasks');
+      // 非正規化（未エンコード等）のディレクトリ名は受け付けない
+      if (encodeIpcNamespaceKey(sourceChatJid) !== namespaceDir) {
+        logger.warn(
+          { namespaceDir, sourceChatJid },
+          'Ignoring non-canonical IPC namespace directory',
+        );
+        continue;
+      }
+
+      const sourceGroup = registeredGroups[sourceChatJid];
+      if (!sourceGroup) {
+        logger.warn(
+          { sourceChatJid },
+          'Ignoring IPC namespace for unregistered group',
+        );
+        continue;
+      }
+
+      const isPrivileged = hasPrivilege(sourceGroup);
+      const messagesDir = path.join(ipcBaseDir, namespaceDir, 'messages');
+      const tasksDir = path.join(ipcBaseDir, namespaceDir, 'tasks');
 
       // このグループの IPC ディレクトリからメッセージを処理
       try {
@@ -156,20 +178,17 @@ export function startIpcWatcher(deps: IpcDeps): void {
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               if (data.type === 'message' && data.chatJid && data.text) {
-                // 認可: このグループが対象の chatJid に送信可能か確認
-                const targetGroup = registeredGroups[data.chatJid];
-                if (
-                  isPrivileged ||
-                  (targetGroup && targetGroup.folder === sourceGroup)
-                ) {
-                  await deps.sendMessage(data.chatJid, data.text);
+                const targetJid = data.chatJid as string;
+                // 認可: 非特権グループは自身の chatJid にのみ送信可能
+                if (isPrivileged || targetJid === sourceChatJid) {
+                  await deps.sendMessage(targetJid, data.text);
                   logger.info(
-                    { chatJid: data.chatJid, sourceGroup },
+                    { chatJid: targetJid, sourceChatJid },
                     'IPC message sent',
                   );
                 } else {
                   logger.warn(
-                    { chatJid: data.chatJid, sourceGroup },
+                    { chatJid: targetJid, sourceChatJid },
                     'Unauthorized IPC message attempt blocked',
                   );
                 }
@@ -177,21 +196,21 @@ export function startIpcWatcher(deps: IpcDeps): void {
               fs.unlinkSync(filePath);
             } catch (err) {
               logger.error(
-                { file, sourceGroup, err },
+                { file, sourceChatJid, err },
                 'Error processing IPC message',
               );
               const errorDir = path.join(ipcBaseDir, 'errors');
               fs.mkdirSync(errorDir, { recursive: true });
               fs.renameSync(
                 filePath,
-                path.join(errorDir, `${sourceGroup}-${file}`),
+                path.join(errorDir, `${namespaceDir}-${file}`),
               );
             }
           }
         }
       } catch (err) {
         logger.error(
-          { err, sourceGroup },
+          { err, sourceChatJid },
           'Error reading IPC messages directory',
         );
       }
@@ -207,24 +226,27 @@ export function startIpcWatcher(deps: IpcDeps): void {
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
               // 認可のため送信元グループの識別情報を processTaskIpc に渡す
-              await processTaskIpc(data, sourceGroup, isPrivileged, deps);
+              await processTaskIpc(data, sourceChatJid, isPrivileged, deps);
               fs.unlinkSync(filePath);
             } catch (err) {
               logger.error(
-                { file, sourceGroup, err },
+                { file, sourceChatJid, err },
                 'Error processing IPC task',
               );
               const errorDir = path.join(ipcBaseDir, 'errors');
               fs.mkdirSync(errorDir, { recursive: true });
               fs.renameSync(
                 filePath,
-                path.join(errorDir, `${sourceGroup}-${file}`),
+                path.join(errorDir, `${namespaceDir}-${file}`),
               );
             }
           }
         }
       } catch (err) {
-        logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
+        logger.error(
+          { err, sourceChatJid },
+          'Error reading IPC tasks directory',
+        );
       }
     }
 
@@ -256,7 +278,7 @@ export async function processTaskIpc(
     group_type?: string;
     thread_defaults?: unknown;
   },
-  sourceGroup: string, // IPC ディレクトリから検証された識別情報
+  sourceChatJid: string, // IPC ディレクトリから検証された識別情報（chat JID）
   isPrivileged: boolean, // main または override の特権を持つか
   deps: IpcDeps,
 ): Promise<void> {
@@ -282,16 +304,16 @@ export async function processTaskIpc(
           break;
         }
 
-        const targetFolder = targetGroupEntry.folder;
-
         // 認可: 特権以外（chat/thread）のグループは自分自身に対してのみスケジュール可能
-        if (!isPrivileged && targetFolder !== sourceGroup) {
+        if (!isPrivileged && targetJid !== sourceChatJid) {
           logger.warn(
-            { sourceGroup, targetFolder },
+            { sourceChatJid, targetJid },
             'Unauthorized schedule_task attempt blocked',
           );
           break;
         }
+
+        const targetFolder = targetGroupEntry.folder;
 
         const scheduleType = data.schedule_type as 'cron' | 'interval' | 'once';
 
@@ -351,7 +373,7 @@ export async function processTaskIpc(
           created_at: new Date().toISOString(),
         });
         logger.info(
-          { taskId, sourceGroup, targetFolder, contextMode },
+          { taskId, sourceChatJid, targetFolder, contextMode },
           'Task created via IPC',
         );
       }
@@ -360,15 +382,15 @@ export async function processTaskIpc(
     case 'pause_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isPrivileged || task.group_folder === sourceGroup)) {
+        if (task && (isPrivileged || task.chat_jid === sourceChatJid)) {
           updateTask(data.taskId, { status: 'paused' });
           logger.info(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Task paused via IPC',
           );
         } else {
           logger.warn(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Unauthorized task pause attempt',
           );
         }
@@ -378,15 +400,15 @@ export async function processTaskIpc(
     case 'resume_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isPrivileged || task.group_folder === sourceGroup)) {
+        if (task && (isPrivileged || task.chat_jid === sourceChatJid)) {
           updateTask(data.taskId, { status: 'active' });
           logger.info(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Task resumed via IPC',
           );
         } else {
           logger.warn(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Unauthorized task resume attempt',
           );
         }
@@ -396,15 +418,15 @@ export async function processTaskIpc(
     case 'cancel_task':
       if (data.taskId) {
         const task = getTaskById(data.taskId);
-        if (task && (isPrivileged || task.group_folder === sourceGroup)) {
+        if (task && (isPrivileged || task.chat_jid === sourceChatJid)) {
           deleteTask(data.taskId);
           logger.info(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Task cancelled via IPC',
           );
         } else {
           logger.warn(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Unauthorized task cancel attempt',
           );
         }
@@ -416,14 +438,14 @@ export async function processTaskIpc(
         const task = getTaskById(data.taskId);
         if (!task) {
           logger.warn(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Task not found for update',
           );
           break;
         }
-        if (!isPrivileged && task.group_folder !== sourceGroup) {
+        if (!isPrivileged && task.chat_jid !== sourceChatJid) {
           logger.warn(
-            { taskId: data.taskId, sourceGroup },
+            { taskId: data.taskId, sourceChatJid },
             'Unauthorized task update attempt',
           );
           break;
@@ -469,7 +491,7 @@ export async function processTaskIpc(
 
         updateTask(data.taskId, updates);
         logger.info(
-          { taskId: data.taskId, sourceGroup, updates },
+          { taskId: data.taskId, sourceChatJid, updates },
           'Task updated via IPC',
         );
       }
@@ -479,16 +501,16 @@ export async function processTaskIpc(
       // 特権グループ（main/override）のみがリフレッシュを要求可能
       if (isPrivileged) {
         logger.info(
-          { sourceGroup },
+          { sourceChatJid },
           'Group metadata refresh requested via IPC',
         );
         await deps.syncGroups(true);
         // 更新されたスナップショットを即座に書き出し
         const availableGroups = deps.getAvailableGroups();
-        deps.writeGroupsSnapshot(sourceGroup, isPrivileged, availableGroups);
+        deps.writeGroupsSnapshot(sourceChatJid, isPrivileged, availableGroups);
       } else {
         logger.warn(
-          { sourceGroup },
+          { sourceChatJid },
           'Unauthorized refresh_groups attempt blocked',
         );
       }
@@ -498,7 +520,7 @@ export async function processTaskIpc(
       // main または override グループのみが新しいグループを登録可能
       if (!isPrivileged) {
         logger.warn(
-          { sourceGroup },
+          { sourceChatJid },
           'Unauthorized register_group attempt blocked',
         );
         break;
@@ -506,14 +528,14 @@ export async function processTaskIpc(
       if (data.jid && data.name && data.folder && data.trigger) {
         if (!isValidGroupFolder(data.folder)) {
           logger.warn(
-            { sourceGroup, folder: data.folder },
+            { sourceChatJid, folder: data.folder },
             'Invalid register_group request - unsafe folder name',
           );
           break;
         }
         // 多層防御: エージェントは IPC 経由で override を設定できない
         if (data.group_type === 'override') {
-          logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
+          logger.warn({ sourceChatJid }, 'override type cannot be set via IPC');
           break;
         }
         const hasGroupType = Object.prototype.hasOwnProperty.call(
@@ -525,7 +547,7 @@ export async function processTaskIpc(
           : null;
         if (hasGroupType && !parsedGroupType) {
           logger.warn(
-            { sourceGroup, group_type: data.group_type },
+            { sourceChatJid, group_type: data.group_type },
             'Invalid group_type in register_group request',
           );
           break;
@@ -533,7 +555,7 @@ export async function processTaskIpc(
         const groupType = parsedGroupType ?? 'chat';
         const validatedThreadDefaults = validateThreadDefaults(
           data.thread_defaults,
-          sourceGroup,
+          sourceChatJid,
         );
         if (validatedThreadDefaults === false) {
           break;
@@ -549,7 +571,12 @@ export async function processTaskIpc(
           thread_defaults: validatedThreadDefaults ?? undefined,
         });
         logger.info(
-          { jid: data.jid, folder: data.folder, groupType, sourceGroup },
+          {
+            jid: data.jid,
+            folder: data.folder,
+            groupType,
+            sourceChatJid,
+          },
           'Group registered via IPC',
         );
       } else {
@@ -564,14 +591,14 @@ export async function processTaskIpc(
       // メイン/override グループのみが既存グループの設定を変更可能
       if (!isPrivileged) {
         logger.warn(
-          { sourceGroup },
+          { sourceChatJid },
           'Unauthorized update_group attempt blocked',
         );
         break;
       }
       // override への変更は IPC 経由で不可
       if (data.group_type === 'override') {
-        logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
+        logger.warn({ sourceChatJid }, 'override type cannot be set via IPC');
         break;
       }
       if (data.jid) {
@@ -584,7 +611,7 @@ export async function processTaskIpc(
           : null;
         if (hasGroupType && !newType) {
           logger.warn(
-            { sourceGroup, group_type: data.group_type },
+            { sourceChatJid, group_type: data.group_type },
             'Invalid group_type in update_group request',
           );
           break;
@@ -594,7 +621,7 @@ export async function processTaskIpc(
           'thread_defaults',
         );
         const validatedThreadDefaults = hasThreadDefaults
-          ? validateThreadDefaults(data.thread_defaults, sourceGroup)
+          ? validateThreadDefaults(data.thread_defaults, sourceChatJid)
           : null;
         if (validatedThreadDefaults === false) {
           break;
@@ -609,7 +636,7 @@ export async function processTaskIpc(
         const targetGroup = registeredGroups[data.jid];
         if (!targetGroup) {
           logger.warn(
-            { sourceGroup, jid: data.jid },
+            { sourceChatJid, jid: data.jid },
             'update_group: target group not found',
           );
           break;
@@ -626,7 +653,7 @@ export async function processTaskIpc(
             jid: data.jid,
             ...(newType ? { newType } : {}),
             threadDefaultsUpdated: hasThreadDefaults,
-            sourceGroup,
+            sourceChatJid,
           },
           'Group updated via IPC',
         );

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -5,7 +5,13 @@ import { CronExpressionParser } from 'cron-parser';
 
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
-import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
+import {
+  _sanitizeContainerConfig,
+  createTask,
+  deleteTask,
+  getTaskById,
+  updateTask,
+} from './db.js';
 import {
   decodeIpcNamespaceKey,
   encodeIpcNamespaceKey,
@@ -79,20 +85,49 @@ function validateThreadDefaults(
     out.requiresTrigger = td.requiresTrigger;
   }
   if (Object.prototype.hasOwnProperty.call(td, 'containerConfig')) {
-    if (
-      typeof td.containerConfig !== 'object' ||
-      td.containerConfig === null ||
-      Array.isArray(td.containerConfig)
-    ) {
+    const ccRaw = td.containerConfig as Record<string, unknown> | null;
+    if (typeof ccRaw !== 'object' || ccRaw === null || Array.isArray(ccRaw)) {
       logger.warn(
         { sourceChatJid, containerConfig: td.containerConfig },
         'Invalid thread_defaults.containerConfig: must be object',
       );
       return false;
     }
-    out.containerConfig = td.containerConfig as NonNullable<
-      ThreadDefaults['containerConfig']
-    >;
+    if (
+      Object.prototype.hasOwnProperty.call(ccRaw, 'timeout') &&
+      (typeof ccRaw.timeout !== 'number' ||
+        !Number.isFinite(ccRaw.timeout) ||
+        ccRaw.timeout <= 0)
+    ) {
+      logger.warn(
+        { sourceChatJid, timeout: ccRaw.timeout },
+        'Invalid thread_defaults.containerConfig.timeout: must be finite positive number',
+      );
+      return false;
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(ccRaw, 'additionalMounts') &&
+      !Array.isArray(ccRaw.additionalMounts)
+    ) {
+      logger.warn(
+        { sourceChatJid, additionalMounts: ccRaw.additionalMounts },
+        'Invalid thread_defaults.containerConfig.additionalMounts: must be array',
+      );
+      return false;
+    }
+    const sanitized = _sanitizeContainerConfig(
+      ccRaw,
+      sourceChatJid,
+      'thread_defaults.containerConfig',
+    );
+    if (!sanitized) {
+      logger.warn(
+        { sourceChatJid },
+        'Invalid thread_defaults.containerConfig in IPC request',
+      );
+      return false;
+    }
+    out.containerConfig = sanitized;
   }
   return out;
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -212,8 +212,14 @@ export function startIpcWatcher(deps: IpcDeps): void {
             const filePath = path.join(messagesDir, file);
             try {
               const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-              if (data.type === 'message' && data.chatJid && data.text) {
-                const targetJid = data.chatJid as string;
+              if (
+                data.type === 'message' &&
+                typeof data.chatJid === 'string' &&
+                typeof data.text === 'string' &&
+                data.chatJid.length > 0 &&
+                data.text.length > 0
+              ) {
+                const targetJid = data.chatJid;
                 // 認可: 非特権グループは自身の chatJid にのみ送信可能
                 if (isPrivileged || targetJid === sourceChatJid) {
                   await deps.sendMessage(targetJid, data.text);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -52,6 +52,7 @@ function validateThreadDefaults(
     return false;
   }
   const td = raw as Record<string, unknown>;
+  const out: ThreadDefaults = {};
   if (Object.prototype.hasOwnProperty.call(td, 'type')) {
     const parsedType = parseIpcThreadDefaultType(td.type);
     if (!parsedType) {
@@ -61,8 +62,35 @@ function validateThreadDefaults(
       );
       return false;
     }
+    out.type = parsedType;
   }
-  return raw as ThreadDefaults;
+  if (Object.prototype.hasOwnProperty.call(td, 'requiresTrigger')) {
+    if (typeof td.requiresTrigger !== 'boolean') {
+      logger.warn(
+        { sourceGroup, requiresTrigger: td.requiresTrigger },
+        'Invalid thread_defaults.requiresTrigger: must be boolean',
+      );
+      return false;
+    }
+    out.requiresTrigger = td.requiresTrigger;
+  }
+  if (Object.prototype.hasOwnProperty.call(td, 'containerConfig')) {
+    if (
+      typeof td.containerConfig !== 'object' ||
+      td.containerConfig === null ||
+      Array.isArray(td.containerConfig)
+    ) {
+      logger.warn(
+        { sourceGroup, containerConfig: td.containerConfig },
+        'Invalid thread_defaults.containerConfig: must be object',
+      );
+      return false;
+    }
+    out.containerConfig = td.containerConfig as NonNullable<
+      ThreadDefaults['containerConfig']
+    >;
+  }
+  return out;
 }
 
 export interface IpcDeps {
@@ -226,7 +254,7 @@ export async function processTaskIpc(
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
     group_type?: string;
-    thread_defaults?: ThreadDefaults;
+    thread_defaults?: unknown;
   },
   sourceGroup: string, // IPC ディレクトリから検証された識別情報
   isPrivileged: boolean, // main または override の特権を持つか
@@ -546,12 +574,33 @@ export async function processTaskIpc(
         logger.warn({ sourceGroup }, 'override type cannot be set via IPC');
         break;
       }
-      if (data.jid && data.group_type) {
-        const newType = parseIpcGroupType(data.group_type);
-        if (!newType) {
+      if (data.jid) {
+        const hasGroupType = Object.prototype.hasOwnProperty.call(
+          data,
+          'group_type',
+        );
+        const newType = hasGroupType ? parseIpcGroupType(data.group_type) : null;
+        if (hasGroupType && !newType) {
           logger.warn(
             { sourceGroup, group_type: data.group_type },
             'Invalid group_type in update_group request',
+          );
+          break;
+        }
+        const hasThreadDefaults = Object.prototype.hasOwnProperty.call(
+          data,
+          'thread_defaults',
+        );
+        const validatedThreadDefaults = hasThreadDefaults
+          ? validateThreadDefaults(data.thread_defaults, sourceGroup)
+          : null;
+        if (validatedThreadDefaults === false) {
+          break;
+        }
+        if (!hasGroupType && !hasThreadDefaults) {
+          logger.warn(
+            { data },
+            'Invalid update_group request - no updatable fields',
           );
           break;
         }
@@ -565,16 +614,24 @@ export async function processTaskIpc(
         }
         deps.registerGroup(data.jid, {
           ...targetGroup,
-          type: newType,
+          ...(newType ? { type: newType } : {}),
+          ...(hasThreadDefaults
+            ? { thread_defaults: validatedThreadDefaults ?? undefined }
+            : {}),
         });
         logger.info(
-          { jid: data.jid, newType, sourceGroup },
-          'Group type updated via IPC',
+          {
+            jid: data.jid,
+            ...(newType ? { newType } : {}),
+            threadDefaultsUpdated: hasThreadDefaults,
+            sourceGroup,
+          },
+          'Group updated via IPC',
         );
       } else {
         logger.warn(
           { data },
-          'Invalid update_group request - missing jid or group_type',
+          'Invalid update_group request - missing jid',
         );
       }
       break;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -58,7 +58,7 @@ function validateThreadDefaults(
     if (!parsedType) {
       logger.warn(
         { sourceGroup, type: td.type },
-        'Invalid or privileged thread_defaults.type in register_group request',
+        'Invalid or privileged thread_defaults.type in IPC request',
       );
       return false;
     }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -71,7 +71,6 @@ export interface SchedulerDependencies {
     groupJid: string,
     proc: ChildProcess,
     containerName: string,
-    groupFolder: string,
   ) => void;
   sendMessage: (jid: string, text: string) => Promise<void>;
 }
@@ -133,10 +132,11 @@ async function runTask(
   const isPrivileged = groupType === 'main' || groupType === 'override';
   const tasks = getAllTasks();
   writeTasksSnapshot(
-    task.group_folder,
+    task.chat_jid,
     isPrivileged,
     tasks.map((t) => ({
       id: t.id,
+      groupJid: t.chat_jid,
       groupFolder: t.group_folder,
       prompt: t.prompt,
       schedule_type: t.schedule_type,
@@ -182,7 +182,7 @@ async function runTask(
         assistantName: ASSISTANT_NAME,
       },
       (proc, containerName) =>
-        deps.onProcess(task.chat_jid, proc, containerName, task.group_folder),
+        deps.onProcess(task.chat_jid, proc, containerName),
       async (streamedOutput: ContainerOutput) => {
         if (streamedOutput.result) {
           result = streamedOutput.result;

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -110,13 +110,11 @@ async function runTask(
   );
 
   const groups = deps.registeredGroups();
-  const group = Object.values(groups).find(
-    (g) => g.folder === task.group_folder,
-  );
+  const group = groups[task.chat_jid];
 
   if (!group) {
     logger.error(
-      { taskId: task.id, groupFolder: task.group_folder },
+      { taskId: task.id, chatJid: task.chat_jid },
       'Group not found for task',
     );
     logTaskRun({
@@ -125,7 +123,7 @@ async function runTask(
       duration_ms: Date.now() - startTime,
       status: 'error',
       result: null,
-      error: `Group not found: ${task.group_folder}`,
+      error: `Group not found: ${task.chat_jid}`,
     });
     return;
   }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -152,9 +152,10 @@ async function runTask(
   let error: string | null = null;
 
   // グループコンテキストモードの場合、グループの現在のセッションを使用します
+  // session キーは group_jid（Phase 3 で group_folder から変更）
   const sessions = deps.getSessions();
   const sessionId =
-    task.context_mode === 'group' ? sessions[task.group_folder] : undefined;
+    task.context_mode === 'group' ? sessions[task.chat_jid] : undefined;
 
   // タスクが結果を出力した後、速やかにコンテナを閉じます。
   // タスクはシングルターン（1往復）であり、クエリループがタイムアウトするまで

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -67,6 +67,8 @@ describe('autoRegisterThread (via _setRegisteredGroups)', () => {
 
     expect(registeredGroups['dc:parent123']).toBeDefined();
     expect(registeredGroups['dc:parent123'].thread_defaults).toBeDefined();
-    expect(registeredGroups['dc:parent123'].thread_defaults!.type).toBe('thread');
+    expect(registeredGroups['dc:parent123'].thread_defaults!.type).toBe(
+      'thread',
+    );
   });
 });

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -208,4 +208,29 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     expect(childType).not.toBe('override');
     expect(childType).toBe('thread');
   });
+
+  it('falls back to thread when parent thread_defaults.type is invalid at runtime', () => {
+    const corruptedParent: RegisteredGroup = {
+      ...parent,
+      thread_defaults: { type: 'main' as unknown as 'thread' },
+    };
+    const msg: InboundMessage = {
+      id: 'msg7',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Grace',
+      content: 'Test',
+      timestamp: '2024-01-01T00:07:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, corruptedParent);
+
+    const childType = registeredGroups[threadJid].type;
+    expect(childType).toBe('thread');
+    expect(setRegisteredGroup).toHaveBeenCalledWith(
+      threadJid,
+      expect.objectContaining({ type: 'thread' }),
+    );
+  });
 });

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -2,7 +2,7 @@
  * thread 自動登録のテスト。
  * discord adapter の onMessage callback を経由した統合テスト的なアプローチ。
  * index.ts の autoRegisterThread は _autoRegisterThread としてエクスポートされ、
- * registeredGroups の状態変化とDB永続化を観察することでテストする。
+ * registeredGroups の状態変化と DB 永続化を観察することでテストする。
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -1,0 +1,72 @@
+/**
+ * thread 自動登録のテスト。
+ * discord adapter の onMessage callback を経由した統合テスト的なアプローチ。
+ * index.ts の autoRegisterThread はプライベートなので、
+ * registeredGroups の状態変化を観察することでテストする。
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('./logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('./db.js', () => ({
+  _initTestDatabase: vi.fn(),
+  getAllRegisteredGroups: vi.fn(() => ({})),
+  getAllSessions: vi.fn(() => ({})),
+  getAllTasks: vi.fn(() => []),
+  getAllChats: vi.fn(() => []),
+  getRouterState: vi.fn(() => null),
+  initDatabase: vi.fn(),
+  setRegisteredGroup: vi.fn(),
+  setRouterState: vi.fn(),
+  setSession: vi.fn(),
+  storeMessage: vi.fn(),
+  storeChatMetadata: vi.fn(),
+  getMessagesSince: vi.fn(() => []),
+  getNewMessages: vi.fn(() => ({ messages: [], newTimestamp: '' })),
+}));
+
+vi.mock('./group-folder.js', () => ({
+  resolveGroupFolderPath: vi.fn(() => '/tmp/test-group'),
+  isValidGroupFolder: vi.fn(() => true),
+}));
+
+vi.mock('fs', () => ({
+  default: { mkdirSync: vi.fn(), existsSync: vi.fn(() => false) },
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+}));
+
+import { _setRegisteredGroups } from './index.js';
+import { RegisteredGroup } from './types.js';
+
+describe('autoRegisterThread (via _setRegisteredGroups)', () => {
+  let registeredGroups: Record<string, RegisteredGroup>;
+
+  beforeEach(() => {
+    registeredGroups = {};
+    _setRegisteredGroups(registeredGroups);
+  });
+
+  it('registeredGroups starts empty', () => {
+    expect(Object.keys(registeredGroups)).toHaveLength(0);
+  });
+
+  it('manually registered parent group is accessible', () => {
+    const parent: RegisteredGroup = {
+      name: 'Parent',
+      folder: 'discord_main',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      type: 'main',
+      thread_defaults: { type: 'thread', requiresTrigger: false },
+    };
+    registeredGroups['dc:parent123'] = parent;
+    _setRegisteredGroups(registeredGroups);
+
+    expect(registeredGroups['dc:parent123']).toBeDefined();
+    expect(registeredGroups['dc:parent123'].thread_defaults).toBeDefined();
+    expect(registeredGroups['dc:parent123'].thread_defaults!.type).toBe('thread');
+  });
+});

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -1,8 +1,8 @@
 /**
  * thread 自動登録のテスト。
  * discord adapter の onMessage callback を経由した統合テスト的なアプローチ。
- * index.ts の autoRegisterThread はプライベートなので、
- * registeredGroups の状態変化を観察することでテストする。
+ * index.ts の autoRegisterThread は _autoRegisterThread としてエクスポートされ、
+ * registeredGroups の状態変化とDB永続化を観察することでテストする。
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -38,8 +38,9 @@ vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
 }));
 
-import { _setRegisteredGroups } from './index.js';
-import { RegisteredGroup } from './types.js';
+import { _setRegisteredGroups, _autoRegisterThread } from './index.js';
+import { setRegisteredGroup } from './db.js';
+import { RegisteredGroup, InboundMessage } from './types.js';
 
 describe('autoRegisterThread (via _setRegisteredGroups)', () => {
   let registeredGroups: Record<string, RegisteredGroup>;
@@ -47,6 +48,7 @@ describe('autoRegisterThread (via _setRegisteredGroups)', () => {
   beforeEach(() => {
     registeredGroups = {};
     _setRegisteredGroups(registeredGroups);
+    vi.clearAllMocks();
   });
 
   it('registeredGroups starts empty', () => {
@@ -70,5 +72,132 @@ describe('autoRegisterThread (via _setRegisteredGroups)', () => {
     expect(registeredGroups['dc:parent123'].thread_defaults!.type).toBe(
       'thread',
     );
+  });
+});
+
+describe('_autoRegisterThread (actual auto-registration path)', () => {
+  let registeredGroups: Record<string, RegisteredGroup>;
+  const parentJid = 'dc:parent123';
+  const threadJid = 'dc:thread456';
+
+  const parent: RegisteredGroup = {
+    name: 'Parent',
+    folder: 'discord_main',
+    trigger: '@Andy',
+    added_at: '2024-01-01T00:00:00.000Z',
+    type: 'main',
+    thread_defaults: { type: 'thread', requiresTrigger: false },
+  };
+
+  beforeEach(() => {
+    registeredGroups = { [parentJid]: parent };
+    _setRegisteredGroups(registeredGroups);
+    vi.clearAllMocks();
+  });
+
+  it('creates a child group entry in registeredGroups', () => {
+    const msg: InboundMessage = {
+      id: 'msg1',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Alice',
+      content: 'Hello thread',
+      timestamp: '2024-01-01T00:01:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, parent);
+
+    expect(registeredGroups[threadJid]).toBeDefined();
+  });
+
+  it('auto-registered child group always has type "thread"', () => {
+    const msg: InboundMessage = {
+      id: 'msg2',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Bob',
+      content: 'Hi',
+      timestamp: '2024-01-01T00:02:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, parent);
+
+    expect(registeredGroups[threadJid].type).toBe('thread');
+  });
+
+  it('child group inherits folder from parent', () => {
+    const msg: InboundMessage = {
+      id: 'msg3',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Carol',
+      content: 'Test',
+      timestamp: '2024-01-01T00:03:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, parent);
+
+    expect(registeredGroups[threadJid].folder).toBe(parent.folder);
+  });
+
+  it('persists child group via setRegisteredGroup', () => {
+    const msg: InboundMessage = {
+      id: 'msg4',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Dave',
+      content: 'Test',
+      timestamp: '2024-01-01T00:04:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, parent);
+
+    expect(setRegisteredGroup).toHaveBeenCalledWith(
+      threadJid,
+      expect.objectContaining({ type: 'thread', folder: parent.folder }),
+    );
+  });
+
+  it('child group requiresTrigger inherits from thread_defaults', () => {
+    const parentWithTrigger: RegisteredGroup = {
+      ...parent,
+      thread_defaults: { type: 'thread', requiresTrigger: true },
+    };
+    const msg: InboundMessage = {
+      id: 'msg5',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Eve',
+      content: 'Test',
+      timestamp: '2024-01-01T00:05:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, parentWithTrigger);
+
+    expect(registeredGroups[threadJid].requiresTrigger).toBe(true);
+  });
+
+  it('does not create a privileged group type even when parent is main', () => {
+    const msg: InboundMessage = {
+      id: 'msg6',
+      chat_jid: threadJid,
+      sender: 'user123',
+      sender_name: 'Frank',
+      content: 'Test',
+      timestamp: '2024-01-01T00:06:00.000Z',
+      parent_jid: parentJid,
+    };
+
+    _autoRegisterThread(threadJid, msg, parent);
+
+    const childType = registeredGroups[threadJid].type;
+    expect(childType).not.toBe('main');
+    expect(childType).not.toBe('override');
+    expect(childType).toBe('thread');
   });
 });

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -212,6 +212,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
   it('falls back to thread when parent thread_defaults.type is invalid at runtime', () => {
     const corruptedParent: RegisteredGroup = {
       ...parent,
+      // runtime 破損データ（DB/JSON改変）を再現するために型制約を意図的にバイパス
       thread_defaults: { type: 'main' as unknown as 'thread' },
     };
     const msg: InboundMessage = {

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -111,7 +111,11 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     expect(registeredGroups[threadJid]).toBeDefined();
   });
 
-  it('auto-registered child group always has type "thread"', () => {
+  it('auto-registered child group reflects thread_defaults.type (chat)', () => {
+    const parentWithChatType: RegisteredGroup = {
+      ...parent,
+      thread_defaults: { type: 'chat', requiresTrigger: false },
+    };
     const msg: InboundMessage = {
       id: 'msg2',
       chat_jid: threadJid,
@@ -122,9 +126,13 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
       parent_jid: parentJid,
     };
 
-    _autoRegisterThread(threadJid, msg, parent);
+    _autoRegisterThread(threadJid, msg, parentWithChatType);
 
-    expect(registeredGroups[threadJid].type).toBe('thread');
+    expect(registeredGroups[threadJid].type).toBe('chat');
+    expect(setRegisteredGroup).toHaveBeenCalledWith(
+      threadJid,
+      expect.objectContaining({ type: 'chat' }),
+    );
   });
 
   it('child group inherits folder from parent', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,9 +50,12 @@ export type ActorRole = 'owner' | 'admin' | 'user';
 /** グループの権限タイプ */
 export type GroupType = 'override' | 'main' | 'chat' | 'thread';
 
+/** thread 自動登録で許可する非特権 group タイプ */
+export type ThreadDefaultGroupType = 'chat' | 'thread';
+
 /** thread 自動登録時に子 group へ継承するデフォルト設定 */
 export interface ThreadDefaults {
-  type?: GroupType; // デフォルト 'thread'
+  type?: ThreadDefaultGroupType; // デフォルト 'thread'
   requiresTrigger?: boolean;
   containerConfig?: ContainerConfig;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,13 @@ export type ActorRole = 'owner' | 'admin' | 'user';
 /** グループの権限タイプ */
 export type GroupType = 'override' | 'main' | 'chat' | 'thread';
 
+/** thread 自動登録時に子 group へ継承するデフォルト設定 */
+export interface ThreadDefaults {
+  type?: GroupType; // デフォルト 'thread'
+  requiresTrigger?: boolean;
+  containerConfig?: ContainerConfig;
+}
+
 export interface RegisteredGroup {
   name: string;
   folder: string;
@@ -58,6 +65,7 @@ export interface RegisteredGroup {
   containerConfig?: ContainerConfig;
   requiresTrigger?: boolean; // デフォルト: グループの場合は true、個人チャットの場合は false
   type?: GroupType; // 未指定時は 'chat' として扱う
+  thread_defaults?: ThreadDefaults; // 設定時、thread message を受信した際に子 group を自動登録する
   channel_mode?: 'chat' | 'url_watch' | 'admin_control';
   chat_behavior?: 'ambient_room_chat' | 'directed_help_chat';
 }
@@ -82,6 +90,8 @@ export interface InboundMessage extends NewMessage {
   place_type?: PlaceType;
   actor_role?: ActorRole;
   is_thread?: boolean;
+  /** Discord thread の親チャンネル JID。callback 専用で DB には保存されない。 */
+  parent_jid?: string;
 }
 
 export interface ScheduledTask {


### PR DESCRIPTION
- [x] Understand the codebase and onMessage flow
- [x] Export `autoRegisterThread` as `_autoRegisterThread` for testing
- [x] Fix JSDoc on `autoRegisterThread` (returns void, not bool)
- [x] Add 6 integration-style tests that exercise the actual auto-registration path in `thread-auto-register.test.ts`
- [x] Run tests — all 8 pass
- [x] Fix task-scheduler to resolve group by `task.chat_jid` instead of `task.group_folder` to avoid ambiguity when multiple thread groups share the same folder
- [x] Validate `thread_defaults.type` in IPC — reject privileged (`main`/`override`) and malformed values before persisting
- [x] Honor `td.type ?? 'thread'` in `autoRegisterThread` so `thread_defaults.type: 'chat'` config is respected
- [x] Fix JSDoc for `validateThreadDefaults` — document `null` for omitted input, `false` for invalid/reject
- [x] Fix `migrateJsonState()` — only migrate `sessions.json` entries whose key matches JID format (`/^[a-z]{2,}:/`), skipping legacy folder-keyed entries
- [x] Fix docs: update thread-implementation-plan to reflect two-stage filtering (discord.ts + onMessage) and autoRegisterThread in onMessage (not startMessageLoop)
- [x] Final validation (all 291 tests pass)