### PR TITLE
feat(discord): URL投稿時にスレッドを自動作成してエージェントに処理させる

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -294,6 +294,23 @@ export class DiscordChannel implements Channel {
     }
   }
 
+  async createThread(parentJid: string, name: string): Promise<string | null> {
+    if (!this.client) return null;
+    try {
+      const channelId = parentJid.replace(/^dc:/, '');
+      const channel = await this.client.channels.fetch(channelId);
+      if (!channel || !('threads' in channel)) return null;
+      const thread = await (channel as TextChannel).threads.create({
+        name: name.slice(0, 100),
+        autoArchiveDuration: 60,
+      });
+      return `dc:${thread.id}`;
+    } catch (err) {
+      logger.error({ parentJid, err }, 'Failed to create Discord thread');
+      return null;
+    }
+  }
+
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
     if (!this.client || !isTyping) return;
     try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -422,9 +422,7 @@ function createSchema(database: Database.Database): void {
 
   // channel_mode カラムが存在しない場合は追加（既存 DB のマイグレーション）
   try {
-    database.exec(
-      `ALTER TABLE registered_groups ADD COLUMN channel_mode TEXT`,
-    );
+    database.exec(`ALTER TABLE registered_groups ADD COLUMN channel_mode TEXT`);
   } catch {
     /* カラムはすでに存在します */
   }
@@ -844,11 +842,13 @@ type RegisteredGroupRow = {
   channel_mode: string | null;
 };
 
-const VALID_CHANNEL_MODES = new Set<string>(['chat', 'url_watch', 'admin_control']);
+const VALID_CHANNEL_MODES = new Set<string>([
+  'chat',
+  'url_watch',
+  'admin_control',
+]);
 
-function parseChannelMode(
-  raw: string | null,
-): RegisteredGroup['channel_mode'] {
+function parseChannelMode(raw: string | null): RegisteredGroup['channel_mode'] {
   if (raw && VALID_CHANNEL_MODES.has(raw))
     return raw as RegisteredGroup['channel_mode'];
   return undefined;
@@ -967,7 +967,13 @@ export function recordSpawnedThread(
   db.prepare(
     `INSERT OR IGNORE INTO spawned_threads (source_message_id, thread_jid, trigger_kind, trigger_value, created_at)
      VALUES (?, ?, ?, ?, ?)`,
-  ).run(sourceMessageId, threadJid, triggerKind, triggerValue, new Date().toISOString());
+  ).run(
+    sourceMessageId,
+    threadJid,
+    triggerKind,
+    triggerValue,
+    new Date().toISOString(),
+  );
 }
 
 // --- JSON マイグレーション ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -254,6 +254,13 @@ function createSchema(database: Database.Database): void {
       group_jid TEXT PRIMARY KEY,
       session_id TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS spawned_threads (
+      source_message_id TEXT PRIMARY KEY,
+      thread_jid        TEXT NOT NULL,
+      trigger_kind      TEXT NOT NULL,
+      trigger_value     TEXT NOT NULL,
+      created_at        TEXT NOT NULL
+    );
     CREATE TABLE IF NOT EXISTS registered_groups (
       jid TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -408,6 +415,15 @@ function createSchema(database: Database.Database): void {
     );
     database.exec(
       `UPDATE chats SET channel = 'telegram', is_group = 1 WHERE jid LIKE 'tg:%'`,
+    );
+  } catch {
+    /* カラムはすでに存在します */
+  }
+
+  // channel_mode カラムが存在しない場合は追加（既存 DB のマイグレーション）
+  try {
+    database.exec(
+      `ALTER TABLE registered_groups ADD COLUMN channel_mode TEXT`,
     );
   } catch {
     /* カラムはすでに存在します */
@@ -814,36 +830,33 @@ export function getAllSessions(): Record<string, string> {
 
 // --- 登録済みグループ・アクセッサー ---
 
-export function getRegisteredGroup(
-  jid: string,
-): (RegisteredGroup & { jid: string }) | undefined {
-  const row = db
-    .prepare('SELECT * FROM registered_groups WHERE jid = ?')
-    .get(jid) as
-    | {
-        jid: string;
-        name: string;
-        folder: string;
-        trigger_pattern: string;
-        added_at: string;
-        container_config: string | null;
-        requires_trigger: number | null;
-        is_main: number | null;
-        group_type: string | null;
-        thread_defaults: string | null;
-      }
-    | undefined;
-  if (!row) return undefined;
-  if (!isValidGroupFolder(row.folder)) {
-    logger.warn(
-      { jid: row.jid, folder: row.folder },
-      'Skipping registered group with invalid folder',
-    );
-    return undefined;
-  }
+type RegisteredGroupRow = {
+  jid: string;
+  name: string;
+  folder: string;
+  trigger_pattern: string;
+  added_at: string;
+  container_config: string | null;
+  requires_trigger: number | null;
+  is_main: number | null;
+  group_type: string | null;
+  thread_defaults: string | null;
+  channel_mode: string | null;
+};
+
+const VALID_CHANNEL_MODES = new Set<string>(['chat', 'url_watch', 'admin_control']);
+
+function parseChannelMode(
+  raw: string | null,
+): RegisteredGroup['channel_mode'] {
+  if (raw && VALID_CHANNEL_MODES.has(raw))
+    return raw as RegisteredGroup['channel_mode'];
+  return undefined;
+}
+
+function rowToRegisteredGroup(row: RegisteredGroupRow): RegisteredGroup {
   const groupType = parseGroupType(row.group_type, row.is_main, row.jid);
   return {
-    jid: row.jid,
     name: row.name,
     folder: row.folder,
     trigger: row.trigger_pattern,
@@ -853,7 +866,25 @@ export function getRegisteredGroup(
       row.requires_trigger === null ? undefined : row.requires_trigger === 1,
     type: groupType,
     thread_defaults: _parseThreadDefaultsJson(row.thread_defaults, row.jid),
+    channel_mode: parseChannelMode(row.channel_mode),
   };
+}
+
+export function getRegisteredGroup(
+  jid: string,
+): (RegisteredGroup & { jid: string }) | undefined {
+  const row = db
+    .prepare('SELECT * FROM registered_groups WHERE jid = ?')
+    .get(jid) as RegisteredGroupRow | undefined;
+  if (!row) return undefined;
+  if (!isValidGroupFolder(row.folder)) {
+    logger.warn(
+      { jid: row.jid, folder: row.folder },
+      'Skipping registered group with invalid folder',
+    );
+    return undefined;
+  }
+  return { jid: row.jid, ...rowToRegisteredGroup(row) };
 }
 
 export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
@@ -869,9 +900,13 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     );
   }
   const groupType = VALID_GROUP_TYPES.has(rawType) ? rawType : 'chat';
+  const channelMode =
+    group.channel_mode && VALID_CHANNEL_MODES.has(group.channel_mode)
+      ? group.channel_mode
+      : null;
   db.prepare(
-    `INSERT INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type, thread_defaults)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main, group_type, thread_defaults, channel_mode)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(jid) DO UPDATE SET
        name = excluded.name,
        folder = excluded.folder,
@@ -881,7 +916,8 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
        requires_trigger = excluded.requires_trigger,
        is_main = excluded.is_main,
        group_type = excluded.group_type,
-       thread_defaults = excluded.thread_defaults`,
+       thread_defaults = excluded.thread_defaults,
+       channel_mode = excluded.channel_mode`,
   ).run(
     jid,
     group.name,
@@ -893,22 +929,14 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     groupType === 'main' || groupType === 'override' ? 1 : 0,
     groupType,
     group.thread_defaults ? JSON.stringify(group.thread_defaults) : null,
+    channelMode,
   );
 }
 
 export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
-  const rows = db.prepare('SELECT * FROM registered_groups').all() as Array<{
-    jid: string;
-    name: string;
-    folder: string;
-    trigger_pattern: string;
-    added_at: string;
-    container_config: string | null;
-    requires_trigger: number | null;
-    is_main: number | null;
-    group_type: string | null;
-    thread_defaults: string | null;
-  }>;
+  const rows = db
+    .prepare('SELECT * FROM registered_groups')
+    .all() as RegisteredGroupRow[];
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
     if (!isValidGroupFolder(row.folder)) {
@@ -918,20 +946,28 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       );
       continue;
     }
-    const groupType = parseGroupType(row.group_type, row.is_main, row.jid);
-    result[row.jid] = {
-      name: row.name,
-      folder: row.folder,
-      trigger: row.trigger_pattern,
-      added_at: row.added_at,
-      containerConfig: _parseContainerConfigJson(row.container_config, row.jid),
-      requiresTrigger:
-        row.requires_trigger === null ? undefined : row.requires_trigger === 1,
-      type: groupType,
-      thread_defaults: _parseThreadDefaultsJson(row.thread_defaults, row.jid),
-    };
+    result[row.jid] = rowToRegisteredGroup(row);
   }
   return result;
+}
+
+export function hasSpawnedThread(sourceMessageId: string): boolean {
+  const row = db
+    .prepare('SELECT 1 FROM spawned_threads WHERE source_message_id = ?')
+    .get(sourceMessageId);
+  return row !== undefined;
+}
+
+export function recordSpawnedThread(
+  sourceMessageId: string,
+  threadJid: string,
+  triggerKind: string,
+  triggerValue: string,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO spawned_threads (source_message_id, thread_jid, trigger_kind, trigger_value, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(sourceMessageId, threadJid, triggerKind, triggerValue, new Date().toISOString());
 }
 
 // --- JSON マイグレーション ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,9 @@ import {
   getNewMessages,
   getRegisteredGroup,
   getRouterState,
+  hasSpawnedThread,
   initDatabase,
+  recordSpawnedThread,
   setRegisteredGroup,
   setRouterState,
   setSession,
@@ -192,6 +194,80 @@ export function _setRegisteredGroups(
 
 /** @internal - テスト用にエクスポート */
 export const _autoRegisterThread = autoRegisterThread;
+
+const URL_RE = /https?:\/\/[^\s<>"]+/g;
+
+/**
+ * url_watch チャンネルに URL が投稿されたとき、Discord スレッドを自動作成して
+ * エージェントに要約させる。
+ */
+async function spawnThreadForUrl(
+  chatJid: string,
+  msg: InboundMessage,
+  group: RegisteredGroup,
+  channel: Channel,
+): Promise<void> {
+  const urls = msg.content.match(URL_RE);
+  if (!urls || urls.length === 0) return;
+  const url = urls[0];
+
+  if (hasSpawnedThread(msg.id)) {
+    logger.debug(
+      { chatJid, msgId: msg.id },
+      'URL thread already spawned for this message; skipping',
+    );
+    return;
+  }
+
+  // スレッド名: ドメイン + パスから生成（最大80文字）
+  let threadName: string;
+  try {
+    const parsed = new URL(url);
+    threadName = `${parsed.hostname}${parsed.pathname}`.slice(0, 80);
+  } catch {
+    threadName = url.slice(0, 80);
+  }
+
+  const threadJid = await channel.createThread!(chatJid, threadName);
+  if (!threadJid) {
+    logger.warn({ chatJid, url }, 'Failed to create Discord thread for URL');
+    return;
+  }
+
+  recordSpawnedThread(msg.id, threadJid, 'url', url);
+
+  // スレッドをグループとして登録（requiresTrigger: false で自動応答）
+  const childGroup: RegisteredGroup = {
+    name: threadName,
+    folder: group.folder,
+    trigger: group.trigger,
+    added_at: new Date().toISOString(),
+    containerConfig: group.containerConfig,
+    requiresTrigger: false,
+    type: 'thread',
+  };
+  registerGroup(threadJid, childGroup);
+
+  // 初期メッセージとして URL を合成保存してエージェントを起動
+  const syntheticMsg: InboundMessage = {
+    id: `${msg.id}_url`,
+    chat_jid: threadJid,
+    sender: msg.sender,
+    sender_name: msg.sender_name,
+    content: url,
+    timestamp: msg.timestamp,
+    is_from_me: false,
+    is_thread: true,
+    parent_jid: chatJid,
+  };
+  storeMessage(syntheticMsg);
+  queue.enqueueMessageCheck(threadJid);
+
+  logger.info(
+    { chatJid, threadJid, url },
+    'URL thread spawned and agent queued',
+  );
+}
 
 /**
  * グループのすべての保留中メッセージを処理します。
@@ -626,6 +702,18 @@ async function main(): Promise<void> {
           return;
         }
       }
+      // url_watch モード: URL が含まれていればスレッドを自動作成してエージェントに渡す
+      const group = registeredGroups[chatJid];
+      if (group?.channel_mode === 'url_watch' && !msg.is_thread) {
+        const ch = findChannel(channels, chatJid);
+        if (ch?.createThread) {
+          spawnThreadForUrl(chatJid, msg, group, ch).catch((err) =>
+            logger.error({ err, chatJid }, 'URL thread spawn failed'),
+          );
+          return; // url_watch チャンネルでは通常のエージェント処理を行わない
+        }
+      }
+
       storeMessage(msg);
     },
     onChatMetadata: (

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -613,7 +613,11 @@ export async function processTaskIpc(
               'container_config',
             )
           : undefined;
-        const VALID_CHANNEL_MODES_IPC = new Set(['chat', 'url_watch', 'admin_control']);
+        const VALID_CHANNEL_MODES_IPC = new Set([
+          'chat',
+          'url_watch',
+          'admin_control',
+        ]);
         const channelMode =
           data.channel_mode != null &&
           VALID_CHANNEL_MODES_IPC.has(data.channel_mode)

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -318,6 +318,7 @@ export async function processTaskIpc(
     containerConfig?: RegisteredGroup['containerConfig'];
     group_type?: string;
     thread_defaults?: unknown;
+    channel_mode?: string;
   },
   sourceChatJid: string, // IPC ディレクトリから検証された識別情報（chat JID）
   isPrivileged: boolean, // main または override の特権を持つか
@@ -612,6 +613,12 @@ export async function processTaskIpc(
               'container_config',
             )
           : undefined;
+        const VALID_CHANNEL_MODES_IPC = new Set(['chat', 'url_watch', 'admin_control']);
+        const channelMode =
+          data.channel_mode != null &&
+          VALID_CHANNEL_MODES_IPC.has(data.channel_mode)
+            ? (data.channel_mode as 'chat' | 'url_watch' | 'admin_control')
+            : undefined;
         deps.registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
@@ -621,12 +628,14 @@ export async function processTaskIpc(
           requiresTrigger: data.requiresTrigger,
           type: groupType,
           thread_defaults: validatedThreadDefaults ?? undefined,
+          channel_mode: channelMode,
         });
         logger.info(
           {
             jid: data.jid,
             folder: data.folder,
             groupType,
+            channelMode,
             sourceChatJid,
           },
           'Group registered via IPC',

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // オプション: プラットフォームからグループ/チャット名を同期する。
   syncGroups?(force: boolean): Promise<void>;
+  // オプション: 親チャンネルにスレッドを作成し、新スレッドの JID を返す。
+  createThread?(parentJid: string, name: string): Promise<string | null>;
 }
 
 // チャネルが受信メッセージを配信するために使用するコールバック型。


### PR DESCRIPTION
## Summary

- `channel_mode: 'url_watch'` なDiscordチャンネルにURLが投稿されると、自動でスレッドを作成してエージェントに処理させる機能を追加
- `spawned_threads` テーブルで同一メッセージへの重複スポーンを防止
- IPC `register_group` で `channel_mode` を受け付けてDBに永続化

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/types.ts` | `Channel.createThread?()` を追加 |
| `src/channels/discord.ts` | `createThread()` 実装（discord.js `threads.create()`） |
| `src/db.ts` | `spawned_threads` テーブル、`channel_mode` カラム、アクセッサー2関数 |
| `src/ipc.ts` | `register_group` で `channel_mode` を受け付ける |
| `src/index.ts` | `spawnThreadForUrl()` 追加、`onMessage` に `url_watch` フックを実装 |

## 動作フロー

1. エージェントが `register_group` IPC で `channel_mode: 'url_watch'` なチャンネルを登録
2. そのチャンネルにURLが投稿される
3. `spawnThreadForUrl()` がURLを抽出し、Discordスレッドを自動作成
4. スレッドをグループとして登録（`requiresTrigger: false`）
5. URLを初期メッセージとして保存してエージェントをキュー投入
6. 通常のエージェント処理はスキップ（`return`）

## Test plan

- [x] `npm run build` でコンパイルエラーなし
- [x] `npm test` で全314テスト通過
- [ ] Discord で `channel_mode: 'url_watch'` なチャンネルを `register_group` IPC で登録
- [ ] そのチャンネルにURLを投稿 → スレッドが自動作成されることを確認
- [ ] スレッド内にエージェントの応答が投稿されることを確認
- [ ] 同じメッセージに再反応しないこと（`spawned_threads` 重複防止）
- [ ] 通常の `channel_mode: 'chat'` チャンネルへのURL投稿でスレッドが作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)