### PR TITLE
feat: implement createThread method with optional messageId for linked threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ groups/global/*
 agents-sdk-docs
 
 docs/clone
+
+.ai/

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -737,6 +737,100 @@ describe('DiscordChannel', () => {
     });
   });
 
+  // --- createThread ---
+
+  describe('createThread', () => {
+    it('creates message-linked thread when messageId is provided', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const mockThreadsCreate = vi
+        .fn()
+        .mockResolvedValue({ id: 'thread-linked-1' });
+      currentClient().channels.fetch.mockResolvedValue({
+        type: 0,
+        threads: { create: mockThreadsCreate },
+      });
+
+      const threadJid = await channel.createThread(
+        'dc:1234567890123456',
+        'linked-thread',
+        'msg_001',
+      );
+
+      expect(currentClient().channels.fetch).toHaveBeenCalledWith(
+        '1234567890123456',
+      );
+      expect(mockThreadsCreate).toHaveBeenCalledTimes(1);
+      expect(mockThreadsCreate).toHaveBeenCalledWith({
+        name: 'linked-thread',
+        autoArchiveDuration: 60,
+        startMessage: 'msg_001',
+      });
+      expect(threadJid).toBe('dc:thread-linked-1');
+    });
+
+    it('falls back to standalone thread when linked creation fails', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const mockThreadsCreate = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('missing source message'))
+        .mockResolvedValueOnce({ id: 'thread-fallback-1' });
+      currentClient().channels.fetch.mockResolvedValue({
+        type: 0,
+        threads: { create: mockThreadsCreate },
+      });
+
+      const threadJid = await channel.createThread(
+        'dc:1234567890123456',
+        'fallback-thread',
+        'msg_missing',
+      );
+
+      expect(mockThreadsCreate).toHaveBeenCalledTimes(2);
+      expect(mockThreadsCreate).toHaveBeenNthCalledWith(1, {
+        name: 'fallback-thread',
+        autoArchiveDuration: 60,
+        startMessage: 'msg_missing',
+      });
+      expect(mockThreadsCreate).toHaveBeenNthCalledWith(2, {
+        name: 'fallback-thread',
+        autoArchiveDuration: 60,
+      });
+      expect(threadJid).toBe('dc:thread-fallback-1');
+    });
+
+    it('creates standalone thread when messageId is omitted', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const mockThreadsCreate = vi
+        .fn()
+        .mockResolvedValue({ id: 'thread-standalone-1' });
+      currentClient().channels.fetch.mockResolvedValue({
+        type: 0,
+        threads: { create: mockThreadsCreate },
+      });
+
+      const threadJid = await channel.createThread(
+        'dc:1234567890123456',
+        'standalone-thread',
+      );
+
+      expect(mockThreadsCreate).toHaveBeenCalledTimes(1);
+      expect(mockThreadsCreate).toHaveBeenCalledWith({
+        name: 'standalone-thread',
+        autoArchiveDuration: 60,
+      });
+      expect(threadJid).toBe('dc:thread-standalone-1');
+    });
+  });
+
   // --- ownsJid ---
 
   describe('ownsJid', () => {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -327,7 +327,7 @@ export class DiscordChannel implements Channel {
       const baseThreadOpts = {
         name: name.slice(0, 100),
         autoArchiveDuration: 60,
-      };
+      } as const;
       if (messageId) {
         try {
           const linkedThread = await (channel as TextChannel).threads.create({

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -307,7 +307,11 @@ export class DiscordChannel implements Channel {
     }
   }
 
-  async createThread(parentJid: string, name: string): Promise<string | null> {
+  async createThread(
+    parentJid: string,
+    name: string,
+    messageId?: string,
+  ): Promise<string | null> {
     if (!this.client) return null;
     try {
       const channelId = parentJid.replace(/^dc:/, '');
@@ -320,10 +324,27 @@ export class DiscordChannel implements Channel {
         );
         return null;
       }
-      const thread = await (channel as TextChannel).threads.create({
+      const baseThreadOpts = {
         name: name.slice(0, 100),
         autoArchiveDuration: 60,
-      });
+      };
+      if (messageId) {
+        try {
+          const linkedThread = await (channel as TextChannel).threads.create({
+            ...baseThreadOpts,
+            startMessage: messageId,
+          });
+          return `dc:${linkedThread.id}`;
+        } catch (err) {
+          logger.warn(
+            { parentJid, messageId, err },
+            'Failed to create Discord message-linked thread; falling back',
+          );
+        }
+      }
+      const thread = await (channel as TextChannel).threads.create(
+        baseThreadOpts,
+      );
       return `dc:${thread.id}`;
     } catch (err) {
       logger.error({ parentJid, err }, 'Failed to create Discord thread');

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,12 +264,10 @@ async function spawnThreadForUrl(
 }
 
 const URL_RE = /https?:\/\/[^\s<>"']+/i;
-const URL_RE_GLOBAL = /https?:\/\/[^\s<>"']+/gi;
 
 function extractFirstUrl(value: string): string | null {
-  const urls = value.match(URL_RE_GLOBAL);
-  if (!urls || urls.length === 0) return null;
-  return urls[0];
+  const firstMatch = value.match(URL_RE);
+  return firstMatch?.[0] ?? null;
 }
 
 function stringContainsUrl(value: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,9 +199,8 @@ async function spawnThreadForUrl(
   group: RegisteredGroup,
   channel: Channel,
 ): Promise<boolean> {
-  const urls = msg.content.match(URL_RE_GLOBAL);
-  if (!urls || urls.length === 0) return false;
-  const url = urls[0];
+  const url = extractFirstUrl(msg.content);
+  if (!url) return false;
 
   // 重複スポーン防止: まず source_message_id を予約してから非同期 createThread を実行する
   const reserved = reserveSpawnedThread(msg.id, 'url', url);
@@ -217,7 +216,7 @@ async function spawnThreadForUrl(
 
   let threadJid: string | null;
   try {
-    threadJid = await channel.createThread!(chatJid, threadName);
+    threadJid = await channel.createThread!(chatJid, threadName, msg.id);
   } catch (err) {
     releaseSpawnedThreadReservation(msg.id);
     logger.error({ err, chatJid, url }, 'Failed to create thread for URL');
@@ -267,6 +266,12 @@ async function spawnThreadForUrl(
 const URL_RE = /https?:\/\/[^\s<>"']+/i;
 const URL_RE_GLOBAL = /https?:\/\/[^\s<>"']+/gi;
 
+function extractFirstUrl(value: string): string | null {
+  const urls = value.match(URL_RE_GLOBAL);
+  if (!urls || urls.length === 0) return null;
+  return urls[0];
+}
+
 function stringContainsUrl(value: string): boolean {
   return URL_RE.test(value);
 }
@@ -276,6 +281,26 @@ function maybeHandleUrlWatchMessage(
   msg: InboundMessage,
   availableChannels: Channel[] = channels,
 ): boolean {
+  const parentGroup = msg.parent_jid
+    ? registeredGroups[msg.parent_jid]
+    : undefined;
+  const isUrlWatchThreadMessage =
+    msg.is_thread === true && parentGroup?.channel_mode === 'url_watch';
+  if (isUrlWatchThreadMessage) {
+    const url = extractFirstUrl(msg.content);
+    if (!url) {
+      storeMessage(msg);
+      return true;
+    }
+    const syntheticMsg: InboundMessage = {
+      ...msg,
+      id: `${msg.id}_url`,
+      content: url,
+    };
+    storeMessage(syntheticMsg);
+    return true;
+  }
+
   const group = registeredGroups[chatJid];
   if (
     group?.channel_mode !== 'url_watch' ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,12 @@ export interface Channel {
   // オプション: プラットフォームからグループ/チャット名を同期する。
   syncGroups?(force: boolean): Promise<void>;
   // オプション: 親チャンネルにスレッドを作成し、新スレッドの JID を返す。
-  createThread?(parentJid: string, name: string): Promise<string | null>;
+  // messageId がある場合は、元メッセージ起点のスレッド作成を試みる。
+  createThread?(
+    parentJid: string,
+    name: string,
+    messageId?: string,
+  ): Promise<string | null>;
 }
 
 // チャネルが受信メッセージを配信するために使用するコールバック型。

--- a/src/url-watch-flow.test.ts
+++ b/src/url-watch-flow.test.ts
@@ -113,6 +113,11 @@ describe('url_watch flow', () => {
     await flushAsyncWork();
 
     expect(createThread).toHaveBeenCalledTimes(1);
+    expect(createThread).toHaveBeenCalledWith(
+      chatJid,
+      expect.any(String),
+      'msg-1',
+    );
     expect(finalizeSpawnedThreadMock).toHaveBeenCalledWith(
       'msg-1',
       'dc:thread-1',
@@ -193,6 +198,99 @@ describe('url_watch flow', () => {
     expect(handled).toBe(true);
     expect(storeMessageMock).toHaveBeenCalledTimes(1);
     expect(storeMessageMock).toHaveBeenCalledWith(msg);
+  });
+
+  it('url_watch 親配下の thread で URL あり: synthetic メッセージを保存する', () => {
+    const threadJid = 'dc:thread-99';
+    _setRegisteredGroups({
+      [chatJid]: baseGroup,
+      [threadJid]: {
+        name: 'Thread',
+        folder: baseGroup.folder,
+        parent_folder: baseGroup.folder,
+        trigger: baseGroup.trigger,
+        added_at: '2024-01-01T00:00:02.000Z',
+        type: 'thread',
+      },
+    });
+    const msg = makeMsg({
+      id: 'msg-thread-url',
+      chat_jid: threadJid,
+      content: 'please summarize https://example.com/next',
+      is_thread: true,
+      parent_jid: chatJid,
+    });
+
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [makeChannel()]);
+
+    expect(handled).toBe(true);
+    expect(storeMessageMock).toHaveBeenCalledTimes(1);
+    expect(storeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'msg-thread-url_url',
+        chat_jid: threadJid,
+        content: 'https://example.com/next',
+        parent_jid: chatJid,
+        is_thread: true,
+      }),
+    );
+    expect(reserveSpawnedThreadMock).not.toHaveBeenCalled();
+  });
+
+  it('url_watch 親配下の thread で URL なし: 元メッセージを通常保存する', () => {
+    const threadJid = 'dc:thread-100';
+    _setRegisteredGroups({
+      [chatJid]: baseGroup,
+      [threadJid]: {
+        name: 'Thread',
+        folder: baseGroup.folder,
+        parent_folder: baseGroup.folder,
+        trigger: baseGroup.trigger,
+        added_at: '2024-01-01T00:00:03.000Z',
+        type: 'thread',
+      },
+    });
+    const msg = makeMsg({
+      id: 'msg-thread-no-url',
+      chat_jid: threadJid,
+      content: 'just chatting',
+      is_thread: true,
+      parent_jid: chatJid,
+    });
+
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [makeChannel()]);
+
+    expect(handled).toBe(true);
+    expect(storeMessageMock).toHaveBeenCalledTimes(1);
+    expect(storeMessageMock).toHaveBeenCalledWith(msg);
+  });
+
+  it('url_watch 以外の親配下 thread は処理せずスキップする', () => {
+    const parentJid = 'dc:parent-non-url-watch';
+    const threadJid = 'dc:thread-101';
+    _setRegisteredGroups({
+      [parentJid]: { ...baseGroup, channel_mode: 'chat' },
+      [threadJid]: {
+        name: 'Thread',
+        folder: baseGroup.folder,
+        parent_folder: baseGroup.folder,
+        trigger: baseGroup.trigger,
+        added_at: '2024-01-01T00:00:04.000Z',
+        type: 'thread',
+      },
+    });
+    const msg = makeMsg({
+      id: 'msg-thread-skipped',
+      chat_jid: threadJid,
+      content: 'https://example.com/not-handled',
+      is_thread: true,
+      parent_jid: parentJid,
+    });
+
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [makeChannel()]);
+
+    expect(handled).toBe(false);
+    expect(storeMessageMock).not.toHaveBeenCalled();
   });
 
 });

--- a/src/url-watch-flow.test.ts
+++ b/src/url-watch-flow.test.ts
@@ -221,7 +221,9 @@ describe('url_watch flow', () => {
       parent_jid: chatJid,
     });
 
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [makeChannel()]);
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
+      makeChannel(),
+    ]);
 
     expect(handled).toBe(true);
     expect(storeMessageMock).toHaveBeenCalledTimes(1);
@@ -258,7 +260,9 @@ describe('url_watch flow', () => {
       parent_jid: chatJid,
     });
 
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [makeChannel()]);
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
+      makeChannel(),
+    ]);
 
     expect(handled).toBe(true);
     expect(storeMessageMock).toHaveBeenCalledTimes(1);
@@ -287,10 +291,11 @@ describe('url_watch flow', () => {
       parent_jid: parentJid,
     });
 
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [makeChannel()]);
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
+      makeChannel(),
+    ]);
 
     expect(handled).toBe(false);
     expect(storeMessageMock).not.toHaveBeenCalled();
   });
-
 });

--- a/src/url-watch-flow.test.ts
+++ b/src/url-watch-flow.test.ts
@@ -239,6 +239,44 @@ describe('url_watch flow', () => {
     expect(reserveSpawnedThreadMock).not.toHaveBeenCalled();
   });
 
+  it('url_watch 親配下の thread で URL 複数: 最初の URL を保存する', () => {
+    const threadJid = 'dc:thread-99-multi';
+    _setRegisteredGroups({
+      [chatJid]: baseGroup,
+      [threadJid]: {
+        name: 'Thread',
+        folder: baseGroup.folder,
+        parent_folder: baseGroup.folder,
+        trigger: baseGroup.trigger,
+        added_at: '2024-01-01T00:00:02.500Z',
+        type: 'thread',
+      },
+    });
+    const msg = makeMsg({
+      id: 'msg-thread-url-multi',
+      chat_jid: threadJid,
+      content:
+        'first https://example.com/first then https://example.com/second',
+      is_thread: true,
+      parent_jid: chatJid,
+    });
+
+    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
+      makeChannel(),
+    ]);
+
+    expect(handled).toBe(true);
+    expect(storeMessageMock).toHaveBeenCalledTimes(1);
+    expect(storeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'msg-thread-url-multi_url',
+        chat_jid: threadJid,
+        content: 'https://example.com/first',
+      }),
+    );
+    expect(reserveSpawnedThreadMock).not.toHaveBeenCalled();
+  });
+
   it('url_watch 親配下の thread で URL なし: 元メッセージを通常保存する', () => {
     const threadJid = 'dc:thread-100';
     _setRegisteredGroups({


### PR DESCRIPTION
- DiscordのcreateThreadメソッドを実装\n- メッセージに対するスレッド作成をサポート\n- optionalなmessageIdパラメータでリンクされたスレッド作成が可能