### PR TITLE
feat: migrate url_watch to thread_per_message

### DIFF
--- a/docs/thread-based-architecture/background.md
+++ b/docs/thread-based-architecture/background.md
@@ -11,7 +11,7 @@
 ## VRC-AI-Bot — コンテキスト駆動
 
 - **場所と文脈の精密なモデリング**: `PlaceType`（7種）、`ActorRole`（3段階）、`Scope`（3種）、`WatchMode`（4種）、`ChatBehavior`（2種）を組み合わせて、メッセージの「どこで・誰が・どんな文脈で」をリッチにモデル化
-- **チャネルごとのモード制御**: 同じサーバー内でもチャネルを `thread_per_message` / `chat` / `admin_control` / `forum_longform` と使い分け
+- **チャネルごとのモード制御**: 同じサーバー内でもチャネルを `thread_per_message` / `chat` / `admin_control` と使い分け
 - **知識管理システム**: AI 応答から知識を抽出・永続化・検索。URL 自動収集とスコープに基づく公開範囲制御
 - **多層アーキテクチャ**: Intake → Queue → Processing → Harness → Knowledge/Reply の明確なパイプライン
 - **エンゲージメントポリシー**: 5段階のトリガーで Bot が「空気を読んで」返信頻度を変える

--- a/docs/thread-based-architecture/background.md
+++ b/docs/thread-based-architecture/background.md
@@ -11,7 +11,7 @@
 ## VRC-AI-Bot — コンテキスト駆動
 
 - **場所と文脈の精密なモデリング**: `PlaceType`（7種）、`ActorRole`（3段階）、`Scope`（3種）、`WatchMode`（4種）、`ChatBehavior`（2種）を組み合わせて、メッセージの「どこで・誰が・どんな文脈で」をリッチにモデル化
-- **チャネルごとのモード制御**: 同じサーバー内でもチャネルを `url_watch` / `chat` / `admin_control` / `forum_longform` と使い分け
+- **チャネルごとのモード制御**: 同じサーバー内でもチャネルを `thread_per_message` / `chat` / `admin_control` / `forum_longform` と使い分け
 - **知識管理システム**: AI 応答から知識を抽出・永続化・検索。URL 自動収集とスコープに基づく公開範囲制御
 - **多層アーキテクチャ**: Intake → Queue → Processing → Harness → Knowledge/Reply の明確なパイプライン
 - **エンゲージメントポリシー**: 5段階のトリガーで Bot が「空気を読んで」返信頻度を変える

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -27,6 +27,7 @@ import {
   storeMessage,
   updateTask,
 } from './db.js';
+import type { RegisteredGroup } from './types.js';
 
 beforeEach(() => {
   _initTestDatabase();
@@ -554,13 +555,29 @@ describe('registered group type', () => {
       parent_folder: 'discord_parent',
       trigger: '@Andy',
       added_at: '2024-01-01T00:00:00.000Z',
-      channel_mode: 'url_watch',
+      channel_mode: 'thread_per_message',
       type: 'chat',
     });
 
     const groups = getAllRegisteredGroups();
     expect(groups['dc:urlwatch'].parent_folder).toBe('discord_parent');
-    expect(groups['dc:urlwatch'].channel_mode).toBe('url_watch');
+    expect(groups['dc:urlwatch'].channel_mode).toBe('thread_per_message');
+  });
+
+  it('maps legacy url_watch channel_mode to thread_per_message', () => {
+    setRegisteredGroup('dc:legacy-urlwatch', {
+      name: 'Legacy URL Watch',
+      folder: 'discord_legacy_urlwatch',
+      trigger: '@Andy',
+      added_at: '2024-01-01T00:00:00.000Z',
+      channel_mode: 'url_watch' as unknown as RegisteredGroup['channel_mode'],
+      type: 'chat',
+    });
+
+    const groups = getAllRegisteredGroups();
+    expect(groups['dc:legacy-urlwatch'].channel_mode).toBe(
+      'thread_per_message',
+    );
   });
 
   it('handles malformed thread_defaults JSON safely', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -886,7 +886,14 @@ function sanitizeParentFolder(
 
 /** channel_mode を DB 値から検証する */
 function parseChannelMode(raw: string | null): RegisteredGroup['channel_mode'] {
-  if (raw === 'chat' || raw === 'url_watch' || raw === 'admin_control') {
+  if (raw === 'url_watch') {
+    return 'thread_per_message';
+  }
+  if (
+    raw === 'chat' ||
+    raw === 'thread_per_message' ||
+    raw === 'admin_control'
+  ) {
     return raw;
   }
   return undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,6 @@ import {
   getAllTasks,
   getMessagesSince,
   getNewMessages,
-  getRegisteredGroup,
   getRouterState,
   initDatabase,
   releaseSpawnedThreadReservation,
@@ -65,7 +64,6 @@ import { hasPrivilege, resolveGroupType } from './group-type.js';
 import {
   Channel,
   InboundMessage,
-  NewMessage,
   RegisteredGroup,
 } from './types.js';
 import { logger } from './logger.js';
@@ -190,41 +188,42 @@ function autoRegisterThread(
 }
 
 /**
- * URL を含むメッセージを受信したとき、Discord スレッドを自動作成してエージェントに要約させる。
- * channel_mode = 'url_watch' のチャンネル専用。
+ * メッセージを受信したとき、Discord スレッドを自動作成してエージェントに処理させる。
+ * channel_mode = 'thread_per_message' のチャンネル専用。
  */
-async function spawnThreadForUrl(
+async function spawnThreadForMessage(
   chatJid: string,
   msg: InboundMessage,
   group: RegisteredGroup,
   channel: Channel,
 ): Promise<boolean> {
-  const url = extractFirstUrl(msg.content);
-  if (!url) return false;
-
   // 重複スポーン防止: まず source_message_id を予約してから非同期 createThread を実行する
-  const reserved = reserveSpawnedThread(msg.id, 'url', url);
+  const reserved = reserveSpawnedThread(
+    msg.id,
+    'thread_per_message',
+    msg.content.slice(0, 256),
+  );
   if (!reserved) return false;
 
-  let threadName: string;
-  try {
-    const parsed = new URL(url);
-    threadName = `${parsed.hostname}${parsed.pathname}`.slice(0, 80);
-  } catch {
-    threadName = url.slice(0, 80);
-  }
+  const threadName = buildThreadNameForMessage(msg);
 
   let threadJid: string | null;
   try {
     threadJid = await channel.createThread!(chatJid, threadName, msg.id);
   } catch (err) {
     releaseSpawnedThreadReservation(msg.id);
-    logger.error({ err, chatJid, url }, 'Failed to create thread for URL');
+    logger.error(
+      { err, chatJid, sourceMessageId: msg.id },
+      'Failed to create thread for message',
+    );
     return false;
   }
   if (!threadJid) {
     releaseSpawnedThreadReservation(msg.id);
-    logger.warn({ chatJid, url }, 'Failed to create thread for URL');
+    logger.warn(
+      { chatJid, sourceMessageId: msg.id },
+      'Failed to create thread for message',
+    );
     return false;
   }
 
@@ -237,28 +236,28 @@ async function spawnThreadForUrl(
     containerConfig: group.containerConfig,
     requiresTrigger: false,
     type: 'thread',
-    channel_mode: 'url_watch',
+    channel_mode: 'thread_per_message',
   };
 
   const syntheticMsg: InboundMessage = {
-    id: `${msg.id}_url`,
+    id: `${msg.id}_thread`,
     chat_jid: threadJid,
     sender: msg.sender,
     sender_name: msg.sender_name,
-    content: url,
+    content: msg.content,
     timestamp: msg.timestamp,
-    is_from_me: true,
+    is_from_me: msg.is_from_me,
     is_thread: true,
     parent_jid: chatJid,
   };
 
-  type UrlWatchInitStage =
+  type ThreadPerMessageInitStage =
     | 'chat_metadata'
     | 'store_message'
     | 'register_group'
     | 'enqueue_initial_task'
     | 'finalize_spawn';
-  let initStage: UrlWatchInitStage = 'chat_metadata';
+  let initStage: ThreadPerMessageInitStage = 'chat_metadata';
   try {
     // programmatic に作成した thread は受信イベントが来ないため、
     // synthetic メッセージ保存前に chats 行を作成して FK 制約を満たす。
@@ -274,28 +273,32 @@ async function spawnThreadForUrl(
     }
 
     initStage = 'enqueue_initial_task';
-    queue.enqueueTask(threadJid, `url-watch-initial:${msg.id}`, async () => {
-      try {
-        const processed = await processMessagesForGroup(
-          threadJid,
-          childGroup,
-          channel,
-        );
-        if (!processed) {
+    queue.enqueueTask(
+      threadJid,
+      `thread-per-message-initial:${msg.id}`,
+      async () => {
+        try {
+          const processed = await processMessagesForGroup(
+            threadJid,
+            childGroup,
+            channel,
+          );
+          if (!processed) {
+            logger.error(
+              { chatJid, threadJid, sourceMessageId: msg.id },
+              'Initial thread-per-message direct processing failed; re-enqueueing message check',
+            );
+            queue.enqueueMessageCheck(threadJid);
+          }
+        } catch (err) {
           logger.error(
-            { chatJid, threadJid, sourceMessageId: msg.id, url },
-            'Initial URL direct processing failed; re-enqueueing message check',
+            { err, chatJid, threadJid, sourceMessageId: msg.id },
+            'Initial thread-per-message direct processing threw; re-enqueueing message check',
           );
           queue.enqueueMessageCheck(threadJid);
         }
-      } catch (err) {
-        logger.error(
-          { err, chatJid, threadJid, sourceMessageId: msg.id, url },
-          'Initial URL direct processing threw; re-enqueueing message check',
-        );
-        queue.enqueueMessageCheck(threadJid);
-      }
-    });
+      },
+    );
 
     initStage = 'finalize_spawn';
     finalizeSpawnedThread(msg.id, threadJid);
@@ -307,17 +310,16 @@ async function spawnThreadForUrl(
         chatJid,
         threadJid,
         sourceMessageId: msg.id,
-        url,
         stage: initStage,
       },
-      'Failed to initialize URL watch thread',
+      'Failed to initialize thread-per-message thread',
     );
     return false;
   }
 
   logger.info(
-    { chatJid, threadJid, url, folder: group.folder },
-    'URL thread spawned',
+    { chatJid, threadJid, folder: group.folder, sourceMessageId: msg.id },
+    'Thread-per-message thread spawned',
   );
   return true;
 }
@@ -329,37 +331,26 @@ function extractFirstUrl(value: string): string | null {
   return firstMatch?.[0] ?? null;
 }
 
-function stringContainsUrl(value: string): boolean {
-  return URL_RE.test(value);
-}
-
-function isUrlWatchThreadGroup(group: RegisteredGroup): boolean {
-  if (group.type !== 'thread') return false;
-  if (group.channel_mode != null) return group.channel_mode === 'url_watch';
-  const parentGroup = group.parent_folder
-    ? getRegisteredGroup(group.parent_folder)
-    : undefined;
-  return parentGroup?.channel_mode === 'url_watch';
-}
-
-function getUrlWatchSeedMessage(
-  chatJid: string,
-  group: RegisteredGroup,
-): NewMessage | null {
-  if (!isUrlWatchThreadGroup(group)) return null;
-  const allMessages = getMessagesSince(chatJid, '', ASSISTANT_NAME).slice(
-    0,
-    1000,
-  );
-  for (const message of allMessages) {
-    const url = extractFirstUrl(message.content);
-    if (!url) continue;
-    return message.content === url ? message : { ...message, content: url };
+function buildThreadNameForMessage(msg: InboundMessage): string {
+  const firstUrl = extractFirstUrl(msg.content);
+  if (firstUrl) {
+    try {
+      const parsed = new URL(firstUrl);
+      const fromUrl = `${parsed.hostname}${parsed.pathname}`.slice(0, 80);
+      if (fromUrl) return fromUrl;
+    } catch {
+      const trimmed = firstUrl.trim().slice(0, 80);
+      if (trimmed) return trimmed;
+    }
   }
-  return null;
+
+  const compact = msg.content.replace(/\s+/g, ' ').trim();
+  if (compact) return compact.slice(0, 80);
+  if (msg.sender_name) return `Thread from ${msg.sender_name}`.slice(0, 80);
+  return 'Thread';
 }
 
-function maybeHandleUrlWatchMessage(
+function maybeHandleThreadPerMessageMessage(
   chatJid: string,
   msg: InboundMessage,
   availableChannels: Channel[] = channels,
@@ -367,26 +358,17 @@ function maybeHandleUrlWatchMessage(
   const parentGroup = msg.parent_jid
     ? registeredGroups[msg.parent_jid]
     : undefined;
-  const isUrlWatchThreadMessage =
-    msg.is_thread === true && parentGroup?.channel_mode === 'url_watch';
-  if (isUrlWatchThreadMessage) {
-    const url = extractFirstUrl(msg.content);
-    if (!url) {
-      storeMessage(msg);
-      return true;
-    }
-    const syntheticMsg: InboundMessage = {
-      ...msg,
-      id: `${msg.id}_url`,
-      content: url,
-    };
-    storeMessage(syntheticMsg);
+  const isThreadPerMessageThreadMessage =
+    msg.is_thread === true &&
+    parentGroup?.channel_mode === 'thread_per_message';
+  if (isThreadPerMessageThreadMessage) {
+    storeMessage(msg);
     return true;
   }
 
   const group = registeredGroups[chatJid];
   if (
-    group?.channel_mode !== 'url_watch' ||
+    group?.channel_mode !== 'thread_per_message' ||
     msg.is_thread === true ||
     Boolean(msg.parent_jid)
   ) {
@@ -399,17 +381,12 @@ function maybeHandleUrlWatchMessage(
     return true;
   }
 
-  if (!stringContainsUrl(msg.content)) {
-    storeMessage(msg);
-    return true;
-  }
-
-  spawnThreadForUrl(chatJid, msg, group, ch)
+  spawnThreadForMessage(chatJid, msg, group, ch)
     .then((handled) => {
       if (!handled) storeMessage(msg);
     })
     .catch((err) => {
-      logger.error({ err, chatJid }, 'URL thread spawn failed');
+      logger.error({ err, chatJid }, 'Thread-per-message spawn failed');
       storeMessage(msg);
     });
   return true;
@@ -441,9 +418,10 @@ export function _setRegisteredGroups(
 }
 
 /** @internal - テスト用にエクスポート */
-export const _spawnThreadForUrl = spawnThreadForUrl;
+export const _spawnThreadForMessage = spawnThreadForMessage;
 /** @internal - テスト用にエクスポート */
-export const _maybeHandleUrlWatchMessage = maybeHandleUrlWatchMessage;
+export const _maybeHandleThreadPerMessageMessage =
+  maybeHandleThreadPerMessageMessage;
 /** @internal - テスト用にエクスポート */
 export const _processMessagesForGroup = processMessagesForGroup;
 
@@ -494,12 +472,7 @@ async function processMessagesForGroup(
     if (!hasTrigger) return true;
   }
 
-  const urlSeedMessage = getUrlWatchSeedMessage(chatJid, group);
-  const promptMessages =
-    urlSeedMessage && !missedMessages.some((m) => m.id === urlSeedMessage.id)
-      ? [urlSeedMessage, ...missedMessages]
-      : missedMessages;
-  const prompt = formatMessages(promptMessages, TIMEZONE);
+  const prompt = formatMessages(missedMessages, TIMEZONE);
 
   // startMessageLoop 内のパイプパスがこれらのメッセージを再取得しないように
   // カーソルを進めます。エラー時にロールバックできるよう古いカーソルを保存します。
@@ -897,8 +870,8 @@ async function main(): Promise<void> {
         }
       }
 
-      // url_watch チャンネル: URL が投稿されたらスレッドを自動作成してエージェントに処理させる
-      if (maybeHandleUrlWatchMessage(chatJid, msg)) return;
+      // thread_per_message チャンネル: すべてのメッセージでスレッド作成を試行する
+      if (maybeHandleThreadPerMessageMessage(chatJid, msg)) return;
 
       storeMessage(msg);
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import { hasPrivilege, resolveGroupType } from './group-type.js';
 import {
   Channel,
   InboundMessage,
+  NewMessage,
   RegisteredGroup,
 } from './types.js';
 import { logger } from './logger.js';

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -796,7 +796,7 @@ describe('register_group group_type', () => {
     );
   });
 
-  it('register_group で legacy channel_mode: url_watch は無効値として無視される', async () => {
+  it('register_group で legacy channel_mode: url_watch は thread_per_message にマッピングされる', async () => {
     await processTaskIpc(
       {
         type: 'register_group',
@@ -813,7 +813,9 @@ describe('register_group group_type', () => {
 
     const allGroups = getAllRegisteredGroups();
     expect(allGroups['legacy-urlwatch@g.us']).toBeDefined();
-    expect(allGroups['legacy-urlwatch@g.us'].channel_mode).toBeUndefined();
+    expect(allGroups['legacy-urlwatch@g.us'].channel_mode).toBe(
+      'thread_per_message',
+    );
   });
 });
 

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -773,6 +773,48 @@ describe('register_group group_type', () => {
     expect(allGroups['sanitize-cc@g.us']).toBeDefined();
     expect(allGroups['sanitize-cc@g.us'].containerConfig).toEqual({});
   });
+
+  it('register_group で channel_mode: thread_per_message を設定できる', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'thread-per-message@g.us',
+        name: 'Thread Per Message',
+        folder: 'thread-per-message',
+        trigger: '@Andy',
+        channel_mode: 'thread_per_message',
+      },
+      'main@g.us',
+      true,
+      deps,
+    );
+
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['thread-per-message@g.us']).toBeDefined();
+    expect(allGroups['thread-per-message@g.us'].channel_mode).toBe(
+      'thread_per_message',
+    );
+  });
+
+  it('register_group で legacy channel_mode: url_watch は無効値として無視される', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'legacy-urlwatch@g.us',
+        name: 'Legacy Url Watch',
+        folder: 'legacy-urlwatch',
+        trigger: '@Andy',
+        channel_mode: 'url_watch',
+      },
+      'main@g.us',
+      true,
+      deps,
+    );
+
+    const allGroups = getAllRegisteredGroups();
+    expect(allGroups['legacy-urlwatch@g.us']).toBeDefined();
+    expect(allGroups['legacy-urlwatch@g.us'].channel_mode).toBeUndefined();
+  });
 });
 
 describe('update_group group_type', () => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -28,7 +28,7 @@ import {
 
 const VALID_CHANNEL_MODES = new Set<
   NonNullable<RegisteredGroup['channel_mode']>
->(['chat', 'url_watch', 'admin_control']);
+>(['chat', 'thread_per_message', 'admin_control']);
 
 function parseIpcGroupType(value: unknown): GroupType | null {
   if (typeof value === 'string' && VALID_GROUP_TYPES.has(value)) {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -44,13 +44,19 @@ function parseIpcChannelMode(
     return undefined;
   }
 
-  if (
-    typeof value === 'string' &&
-    VALID_CHANNEL_MODES.has(
-      value as NonNullable<RegisteredGroup['channel_mode']>,
-    )
-  ) {
-    return value as RegisteredGroup['channel_mode'];
+  if (typeof value === 'string') {
+    // Legacy alias: url_watch → thread_per_message
+    if (value === 'url_watch') {
+      return 'thread_per_message';
+    }
+
+    if (
+      VALID_CHANNEL_MODES.has(
+        value as NonNullable<RegisteredGroup['channel_mode']>,
+      )
+    ) {
+      return value as RegisteredGroup['channel_mode'];
+    }
   }
 
   logger.warn(

--- a/src/thread-per-message-flow.test.ts
+++ b/src/thread-per-message-flow.test.ts
@@ -82,7 +82,6 @@ vi.mock('./db.js', () => ({
   getAllChats: vi.fn(() => []),
   getMessagesSince: getMessagesSinceMock,
   getNewMessages: vi.fn(() => ({ messages: [], newTimestamp: '' })),
-  getRegisteredGroup: vi.fn(),
   getRouterState: vi.fn(() => null),
   initDatabase: vi.fn(),
   releaseSpawnedThreadReservation: releaseSpawnedThreadReservationMock,
@@ -134,7 +133,7 @@ vi.mock('fs', () => ({
 }));
 
 import {
-  _maybeHandleUrlWatchMessage,
+  _maybeHandleThreadPerMessageMessage,
   _processMessagesForGroup,
   _setRegisteredGroups,
 } from './index.js';
@@ -146,7 +145,7 @@ const baseGroup: RegisteredGroup = {
   trigger: '@Andy',
   added_at: '2024-01-01T00:00:00.000Z',
   type: 'chat',
-  channel_mode: 'url_watch',
+  channel_mode: 'thread_per_message',
 };
 
 function makeMsg(overrides?: Partial<InboundMessage>): InboundMessage {
@@ -179,7 +178,7 @@ async function flushAsyncWork(turns = 6): Promise<void> {
   }
 }
 
-describe('url_watch flow', () => {
+describe('thread_per_message flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStoredMessages();
@@ -187,11 +186,11 @@ describe('url_watch flow', () => {
     _setRegisteredGroups({ [chatJid]: baseGroup });
   });
 
-  it('URL あり + createThread 成功: スレッド作成し元メッセージ保存をスキップ', async () => {
+  it('createThread 成功時はスレッド作成し元メッセージ保存をスキップ', async () => {
     const createThread = vi.fn(async () => 'dc:thread-1');
     const msg = makeMsg();
 
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
       makeChannel(createThread),
     ]);
     expect(handled).toBe(true);
@@ -212,6 +211,7 @@ describe('url_watch flow', () => {
       expect.objectContaining({
         type: 'thread',
         parent_folder: 'discord_main',
+        channel_mode: 'thread_per_message',
       }),
     );
     expect(storeChatMetadataMock).toHaveBeenCalledWith(
@@ -224,24 +224,14 @@ describe('url_watch flow', () => {
     expect(storeMessageMock).toHaveBeenCalledTimes(1);
     expect(storeMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: 'msg-1_url',
+        id: 'msg-1_thread',
         chat_jid: 'dc:thread-1',
         content: 'https://example.com/post',
       }),
     );
-    const metadataCallOrder =
-      storeChatMetadataMock.mock.invocationCallOrder[0] ?? -1;
-    const syntheticStoreCallOrder =
-      storeMessageMock.mock.invocationCallOrder[0] ?? -1;
-    const enqueueTaskCallOrder =
-      enqueueTaskMock.mock.invocationCallOrder[0] ?? -1;
-    const finalizeCallOrder =
-      finalizeSpawnedThreadMock.mock.invocationCallOrder[0] ?? -1;
-    expect(metadataCallOrder).toBeLessThan(syntheticStoreCallOrder);
-    expect(enqueueTaskCallOrder).toBeLessThan(finalizeCallOrder);
     expect(enqueueTaskMock).toHaveBeenCalledWith(
       'dc:thread-1',
-      'url-watch-initial:msg-1',
+      'thread-per-message-initial:msg-1',
     );
     expect(enqueueMessageCheckMock).not.toHaveBeenCalled();
     expect(runContainerAgentMock).toHaveBeenCalledTimes(1);
@@ -253,6 +243,26 @@ describe('url_watch flow', () => {
     expect(firstPrompt).toContain('https://example.com/post');
   });
 
+  it('URL なしでも createThread を実行してスレッドへ保存する', async () => {
+    const createThread = vi.fn(async () => 'dc:thread-no-url');
+    const msg = makeMsg({ id: 'msg-no-url', content: 'hello world' });
+
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
+      makeChannel(createThread),
+    ]);
+    expect(handled).toBe(true);
+    await flushAsyncWork();
+
+    expect(createThread).toHaveBeenCalledTimes(1);
+    expect(storeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'msg-no-url_thread',
+        chat_jid: 'dc:thread-no-url',
+        content: 'hello world',
+      }),
+    );
+  });
+
   it('初期化失敗時は予約解放し元メッセージ保存へフォールバックする', async () => {
     const createThread = vi.fn(async () => 'dc:thread-init-fail');
     const msg = makeMsg({ id: 'msg-init-fail' });
@@ -260,7 +270,7 @@ describe('url_watch flow', () => {
       throw new Error('chat metadata failed');
     });
 
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
       makeChannel(createThread),
     ]);
     expect(handled).toBe(true);
@@ -279,30 +289,15 @@ describe('url_watch flow', () => {
         threadJid: 'dc:thread-init-fail',
         stage: 'chat_metadata',
       }),
-      'Failed to initialize URL watch thread',
+      'Failed to initialize thread-per-message thread',
     );
   });
 
-  it('URL なし: 元メッセージを通常保存する', async () => {
-    const createThread = vi.fn(async () => 'dc:thread-1');
-    const msg = makeMsg({ id: 'msg-no-url', content: 'hello world' });
-
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [
-      makeChannel(createThread),
-    ]);
-    expect(handled).toBe(true);
-    await flushAsyncWork();
-
-    expect(createThread).not.toHaveBeenCalled();
-    expect(storeMessageMock).toHaveBeenCalledTimes(1);
-    expect(storeMessageMock).toHaveBeenCalledWith(msg);
-  });
-
-  it('URL あり + createThread が null: 元メッセージを通常保存する', async () => {
+  it('createThread が null の場合は元メッセージを通常保存する', async () => {
     const createThread = vi.fn(async () => null);
     const msg = makeMsg({ id: 'msg-null-thread' });
 
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
       makeChannel(createThread),
     ]);
     expect(handled).toBe(true);
@@ -316,13 +311,13 @@ describe('url_watch flow', () => {
     expect(storeMessageMock).toHaveBeenCalledWith(msg);
   });
 
-  it('URL あり + createThread が例外: 元メッセージを通常保存する', async () => {
+  it('createThread が例外の場合は元メッセージを通常保存する', async () => {
     const createThread = vi.fn(async () => {
       throw new Error('createThread failed');
     });
     const msg = makeMsg({ id: 'msg-create-throws' });
 
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
       makeChannel(createThread),
     ]);
     expect(handled).toBe(true);
@@ -336,38 +331,17 @@ describe('url_watch flow', () => {
     expect(storeMessageMock).toHaveBeenCalledWith(msg);
   });
 
-  it('初回直接起動が失敗したらエラーログを残す', async () => {
-    runContainerAgentMock.mockResolvedValueOnce({
-      status: 'error',
-    });
-    const createThread = vi.fn(async () => 'dc:thread-direct-fail');
-    const msg = makeMsg({ id: 'msg-direct-fail' });
-
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [
-      makeChannel(createThread),
-    ]);
-    expect(handled).toBe(true);
-    await flushAsyncWork();
-
-    expect(loggerErrorMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        chatJid,
-        threadJid: 'dc:thread-direct-fail',
-        sourceMessageId: 'msg-direct-fail',
-      }),
-      'Initial URL direct processing failed; re-enqueueing message check',
-    );
-  });
-
-  it('url_watch で createThread が未実装でも元メッセージを保存する', () => {
+  it('createThread が未実装でも元メッセージを保存する', () => {
     const msg = makeMsg({ id: 'msg-no-create-thread' });
-    const handled = _maybeHandleUrlWatchMessage(chatJid, msg, [makeChannel()]);
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
+      makeChannel(),
+    ]);
     expect(handled).toBe(true);
     expect(storeMessageMock).toHaveBeenCalledTimes(1);
     expect(storeMessageMock).toHaveBeenCalledWith(msg);
   });
 
-  it('url_watch 親配下の thread で URL あり: synthetic メッセージを保存する', () => {
+  it('thread_per_message 親配下の thread メッセージはそのまま保存する', () => {
     const threadJid = 'dc:thread-99';
     _setRegisteredGroups({
       [chatJid]: baseGroup,
@@ -378,103 +352,28 @@ describe('url_watch flow', () => {
         trigger: baseGroup.trigger,
         added_at: '2024-01-01T00:00:02.000Z',
         type: 'thread',
+        channel_mode: 'thread_per_message',
       },
     });
     const msg = makeMsg({
-      id: 'msg-thread-url',
+      id: 'msg-thread',
       chat_jid: threadJid,
       content: 'please summarize https://example.com/next',
       is_thread: true,
       parent_jid: chatJid,
     });
 
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
-      makeChannel(),
-    ]);
-
-    expect(handled).toBe(true);
-    expect(storeMessageMock).toHaveBeenCalledTimes(1);
-    expect(storeMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'msg-thread-url_url',
-        chat_jid: threadJid,
-        content: 'https://example.com/next',
-        parent_jid: chatJid,
-        is_thread: true,
-      }),
-    );
-    expect(reserveSpawnedThreadMock).not.toHaveBeenCalled();
-  });
-
-  it('url_watch 親配下の thread で URL 複数: 最初の URL を保存する', () => {
-    const threadJid = 'dc:thread-99-multi';
-    _setRegisteredGroups({
-      [chatJid]: baseGroup,
-      [threadJid]: {
-        name: 'Thread',
-        folder: baseGroup.folder,
-        parent_folder: baseGroup.folder,
-        trigger: baseGroup.trigger,
-        added_at: '2024-01-01T00:00:02.500Z',
-        type: 'thread',
-      },
-    });
-    const msg = makeMsg({
-      id: 'msg-thread-url-multi',
-      chat_jid: threadJid,
-      content:
-        'first https://example.com/first then https://example.com/second',
-      is_thread: true,
-      parent_jid: chatJid,
-    });
-
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
-      makeChannel(),
-    ]);
-
-    expect(handled).toBe(true);
-    expect(storeMessageMock).toHaveBeenCalledTimes(1);
-    expect(storeMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'msg-thread-url-multi_url',
-        chat_jid: threadJid,
-        content: 'https://example.com/first',
-      }),
-    );
-    expect(reserveSpawnedThreadMock).not.toHaveBeenCalled();
-  });
-
-  it('url_watch 親配下の thread で URL なし: 元メッセージを通常保存する', () => {
-    const threadJid = 'dc:thread-100';
-    _setRegisteredGroups({
-      [chatJid]: baseGroup,
-      [threadJid]: {
-        name: 'Thread',
-        folder: baseGroup.folder,
-        parent_folder: baseGroup.folder,
-        trigger: baseGroup.trigger,
-        added_at: '2024-01-01T00:00:03.000Z',
-        type: 'thread',
-      },
-    });
-    const msg = makeMsg({
-      id: 'msg-thread-no-url',
-      chat_jid: threadJid,
-      content: 'just chatting',
-      is_thread: true,
-      parent_jid: chatJid,
-    });
-
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
+    const handled = _maybeHandleThreadPerMessageMessage(threadJid, msg, [
       makeChannel(),
     ]);
 
     expect(handled).toBe(true);
     expect(storeMessageMock).toHaveBeenCalledTimes(1);
     expect(storeMessageMock).toHaveBeenCalledWith(msg);
+    expect(reserveSpawnedThreadMock).not.toHaveBeenCalled();
   });
 
-  it('url_watch スレッド後続会話でも初回 URL をコンテキストに含める', async () => {
+  it('thread_per_message 後続会話では URL seed を自動挿入しない', async () => {
     const threadJid = 'dc:thread-context';
     const threadGroup: RegisteredGroup = {
       name: 'Thread',
@@ -484,15 +383,15 @@ describe('url_watch flow', () => {
       added_at: '2024-01-01T00:00:02.000Z',
       requiresTrigger: false,
       type: 'thread',
-      channel_mode: 'url_watch',
+      channel_mode: 'thread_per_message',
     };
     _setRegisteredGroups({
       [chatJid]: baseGroup,
       [threadJid]: threadGroup,
     });
 
-    const initialUrl = makeMsg({
-      id: 'msg-thread-seed',
+    const initial = makeMsg({
+      id: 'msg-thread-initial',
       chat_jid: threadJid,
       content: 'https://example.com/root',
       timestamp: '2024-01-01T00:00:10.000Z',
@@ -508,10 +407,10 @@ describe('url_watch flow', () => {
       parent_jid: chatJid,
     });
 
-    _maybeHandleUrlWatchMessage(threadJid, initialUrl, [makeChannel()]);
+    _maybeHandleThreadPerMessageMessage(threadJid, initial, [makeChannel()]);
     await _processMessagesForGroup(threadJid, threadGroup, makeChannel());
     runContainerAgentMock.mockClear();
-    _maybeHandleUrlWatchMessage(threadJid, followup, [makeChannel()]);
+    _maybeHandleThreadPerMessageMessage(threadJid, followup, [makeChannel()]);
     await _processMessagesForGroup(threadJid, threadGroup, makeChannel());
 
     expect(runContainerAgentMock).toHaveBeenCalledTimes(1);
@@ -520,12 +419,12 @@ describe('url_watch flow', () => {
       | undefined;
     const followupPrompt =
       (followupCall?.[1] as { prompt?: string } | undefined)?.prompt ?? '';
-    expect(followupPrompt).toContain('https://example.com/root');
     expect(followupPrompt).toContain('next question without url');
+    expect(followupPrompt).not.toContain('https://example.com/root');
   });
 
-  it('url_watch 以外の親配下 thread は処理せずスキップする', () => {
-    const parentJid = 'dc:parent-non-url-watch';
+  it('thread_per_message 以外の親配下 thread はこのハンドラで処理しない', () => {
+    const parentJid = 'dc:parent-non-thread-per-message';
     const threadJid = 'dc:thread-101';
     _setRegisteredGroups({
       [parentJid]: { ...baseGroup, channel_mode: 'chat' },
@@ -546,11 +445,34 @@ describe('url_watch flow', () => {
       parent_jid: parentJid,
     });
 
-    const handled = _maybeHandleUrlWatchMessage(threadJid, msg, [
+    const handled = _maybeHandleThreadPerMessageMessage(threadJid, msg, [
       makeChannel(),
     ]);
 
     expect(handled).toBe(false);
     expect(storeMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('初回直接起動が失敗したらエラーログを残す', async () => {
+    runContainerAgentMock.mockResolvedValueOnce({
+      status: 'error',
+    });
+    const createThread = vi.fn(async () => 'dc:thread-direct-fail');
+    const msg = makeMsg({ id: 'msg-direct-fail' });
+
+    const handled = _maybeHandleThreadPerMessageMessage(chatJid, msg, [
+      makeChannel(createThread),
+    ]);
+    expect(handled).toBe(true);
+    await flushAsyncWork();
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatJid,
+        threadJid: 'dc:thread-direct-fail',
+        sourceMessageId: 'msg-direct-fail',
+      }),
+      'Initial thread-per-message direct processing failed; re-enqueueing message check',
+    );
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface RegisteredGroup {
   requiresTrigger?: boolean; // デフォルト: グループの場合は true、個人チャットの場合は false
   type?: GroupType; // 未指定時は 'chat' として扱う
   thread_defaults?: ThreadDefaults; // 設定時、thread message を受信した際に子 group を自動登録する
-  channel_mode?: 'chat' | 'url_watch' | 'admin_control';
+  channel_mode?: 'chat' | 'thread_per_message' | 'admin_control';
   chat_behavior?: 'ambient_room_chat' | 'directed_help_chat';
 }
 


### PR DESCRIPTION
## Summary
This PR migrates the `url_watch` table to use `thread_per_message` instead of `thread_all`, improving isolation and scalability for URL-based message handling.

## Changes
- Migrated `url_watch` to `thread_per_message` architecture
- Fixed missing `NewMessage` import
- Updated related tests and types
- Refactored message flow handling for better thread isolation

## Files Changed
- `src/db.ts` & `src/db.test.ts` - Database schema and tests
- `src/index.ts` - Main message handling logic
- `src/ipc.ts` & `src/ipc-auth.test.ts` - IPC handling and auth tests
- `src/types.ts` - Type definitions
- Test file renamed: `url-watch-flow.test.ts` → `thread-per-message-flow.test.ts`
- Documentation updates

## Testing
- Unit tests updated and passing
- IPC auth tests added/improved