### PR TITLE
fix: credential proxy の ETIMEDOUT 対策と接続エラー処理を改善

### DIFF
--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -90,7 +90,10 @@ describe('credential-proxy', () => {
   let proxyPort: number;
   let upstreamPort: number;
   let lastUpstreamHeaders: http.IncomingHttpHeaders;
-  let upstreamHandler: (req: http.IncomingMessage, res: http.ServerResponse) => void;
+  let upstreamHandler: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ) => void;
 
   beforeEach(async () => {
     lastUpstreamHeaders = {};

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -43,20 +43,65 @@ function makeRequest(
   });
 }
 
+function makeRequestUntilDone(
+  port: number,
+  options: http.RequestOptions,
+  body = '',
+): Promise<{
+  statusCode: number;
+  body: string;
+  terminalEvent: 'end' | 'close' | 'aborted';
+}> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { ...options, hostname: '127.0.0.1', port },
+      (res) => {
+        const chunks: Buffer[] = [];
+        let settled = false;
+        const finish = (terminalEvent: 'end' | 'close' | 'aborted') => {
+          if (settled) return;
+          settled = true;
+          resolve({
+            statusCode: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+            terminalEvent,
+          });
+        };
+
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => finish('end'));
+        res.on('close', () => finish('close'));
+        res.on('aborted', () => finish('aborted'));
+      },
+    );
+
+    req.setTimeout(2_000, () => {
+      req.destroy(new Error('request timeout'));
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
 describe('credential-proxy', () => {
   let proxyServer: http.Server;
   let upstreamServer: http.Server;
   let proxyPort: number;
   let upstreamPort: number;
   let lastUpstreamHeaders: http.IncomingHttpHeaders;
+  let upstreamHandler: (req: http.IncomingMessage, res: http.ServerResponse) => void;
 
   beforeEach(async () => {
     lastUpstreamHeaders = {};
-
-    upstreamServer = http.createServer((req, res) => {
+    upstreamHandler = (req, res) => {
       lastUpstreamHeaders = { ...req.headers };
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
+    };
+
+    upstreamServer = http.createServer((req, res) => {
+      upstreamHandler(req, res);
     });
     await new Promise<void>((resolve) =>
       upstreamServer.listen(0, '127.0.0.1', resolve),
@@ -188,5 +233,51 @@ describe('credential-proxy', () => {
 
     expect(res.statusCode).toBe(502);
     expect(res.body).toBe('Bad Gateway');
+  });
+
+  it('handles upstream error after headers are sent without hanging downstream', async () => {
+    proxyPort = await startProxy({ ANTHROPIC_API_KEY: 'sk-ant-real-key' });
+
+    upstreamHandler = (req, res) => {
+      lastUpstreamHeaders = { ...req.headers };
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write('partial');
+      setImmediate(() => {
+        res.socket?.destroy(new Error('upstream disconnected after headers'));
+      });
+    };
+
+    const brokenResponse = await makeRequestUntilDone(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(brokenResponse.statusCode).toBe(200);
+    expect(['aborted', 'close', 'end']).toContain(brokenResponse.terminalEvent);
+    expect(proxyServer.listening).toBe(true);
+
+    upstreamHandler = (req, res) => {
+      lastUpstreamHeaders = { ...req.headers };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+
+    const recoveryResponse = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(recoveryResponse.statusCode).toBe(200);
+    expect(recoveryResponse.body).toContain('"ok":true');
   });
 });

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -90,8 +90,21 @@ export function startCredentialProxy(
           (upRes) => {
             res.writeHead(upRes.statusCode!, upRes.headers);
             upRes.pipe(res);
+            // ストリーミング中の接続断を適切に処理
+            upRes.on('error', (err) => {
+              logger.error(
+                { err, url: req.url },
+                'Credential proxy upstream response error',
+              );
+              if (!res.destroyed) res.destroy();
+            });
           },
         );
+
+        // TCPキープアライブを有効化 — 長いストリーミング中の ETIMEDOUT を防ぐ
+        upstream.on('socket', (socket) => {
+          socket.setKeepAlive(true, 30_000);
+        });
 
         upstream.on('error', (err) => {
           logger.error(
@@ -101,7 +114,14 @@ export function startCredentialProxy(
           if (!res.headersSent) {
             res.writeHead(502);
             res.end('Bad Gateway');
+          } else if (!res.destroyed) {
+            res.destroy();
           }
+        });
+
+        // クライアント（コンテナ）が切断したら upstream も中止
+        req.on('close', () => {
+          if (!upstream.destroyed) upstream.destroy();
         });
 
         upstream.write(body);

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -101,9 +101,24 @@ export function startCredentialProxy(
           },
         );
 
-        // TCPキープアライブを有効化 — 長いストリーミング中の ETIMEDOUT を防ぐ
-        upstream.on('socket', (socket) => {
-          socket.setKeepAlive(true, 30_000);
+        // TCPキープアライブを有効化して長いストリーミング中の ETIMEDOUT を防ぐ。
+        // 30_000 は最初の keepalive probe までの初期遅延（ms）で、以降の間隔は OS 依存。
+        const applyKeepAlive = () => {
+          if (!upstream.socket) return false;
+          upstream.socket.setKeepAlive(true, 30_000);
+          return true;
+        };
+        if (!applyKeepAlive()) {
+          upstream.once('socket', () => {
+            applyKeepAlive();
+          });
+        }
+
+        // 下流（コンテナ側）が切断したら upstream を即時中止する。
+        res.on('close', () => {
+          if (!res.writableEnded && !upstream.destroyed) {
+            upstream.destroy();
+          }
         });
 
         upstream.on('error', (err) => {

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -119,11 +119,6 @@ export function startCredentialProxy(
           }
         });
 
-        // クライアント（コンテナ）が切断したら upstream も中止
-        req.on('close', () => {
-          if (!upstream.destroyed) upstream.destroy();
-        });
-
         upstream.write(body);
         upstream.end();
       });


### PR DESCRIPTION
## Summary

- TCPキープアライブを有効化（初期遅延30秒、以降の間隔はOS依存）し、長いストリーミング中の `ETIMEDOUT` を防止
- `upRes` にエラーハンドラを追加し、ヘッダー送信後の接続断を `res.destroy()` でクリーンに処理
- ヘッダー送信後に upstream エラーが発生した場合の `else if (!res.destroyed)` ブランチを追加
- クライアント（コンテナ）切断時に upstream 接続を即座に中止

## Background

URLを投稿してエージェントが WebFetch + API呼び出しを行う際、ストリーミング中に `read ETIMEDOUT` が発生してコンテナがクラッシュするケースが確認された。根本原因は credential proxy の upstream 接続に TCP keepalive が設定されていなかったこと。

## Test plan

- [ ] `npm run build` が通ること
- [ ] URL投稿 → エージェントが WebFetch → 正常に要約が返ること
- [ ] ログに `ETIMEDOUT` が出なくなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)