### PR TITLE
feat: Add Codex OAuth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,8 @@ DISCORD_BOT_TOKEN=
 
 # OpenAI Codex OAuth 認証ファイルパス
 # デフォルト: ~/.codex/auth.json (`codex login` で作成)
-# 直接注入のため ALLOW_DIRECT_SECRET_INJECTION=true が必要
+# ホスト側 credential-proxy がこのファイルを読み、Bearer トークンを注入
 # OAS_CODEX_AUTH_PATH=~/.codex/auth.json
 
-# 直接シークレット注入を許可 (Gemini/Codex で必須)
+# 直接シークレット注入を許可 (Gemini でのみ必須)
 # ALLOW_DIRECT_SECRET_INJECTION=true

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -317,6 +317,15 @@ function resolveSessionProviderConfig(env: NodeJS.ProcessEnv): SessionProviderCo
     };
   }
 
+  if (env.CODEX_BASE_URL) {
+    return {
+      provider: 'codex',
+      model: DEFAULT_MODEL_BY_PROVIDER.codex,
+      apiKey: env.CODEX_API_KEY || 'placeholder',
+      baseURL: env.CODEX_BASE_URL,
+    };
+  }
+
   if (env.OAS_CODEX_OAUTH_JSON) {
     return {
       provider: 'codex',
@@ -326,7 +335,7 @@ function resolveSessionProviderConfig(env: NodeJS.ProcessEnv): SessionProviderCo
   }
 
   throw new Error(
-    'No provider credentials found. Set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, or OAS_CODEX_OAUTH_JSON.',
+    'No provider credentials found. Set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, CODEX_BASE_URL, or OAS_CODEX_OAUTH_JSON.',
   );
 }
 
@@ -886,7 +895,8 @@ async function main(): Promise<void> {
 
   // 認証情報はホスト側で注入される。
   // Anthropic/OpenAI は BASE_URL + placeholder を使ってプロキシ経由、
-  // Gemini/Codex の直接注入は ALLOW_DIRECT_SECRET_INJECTION=true の明示オプトイン時のみ許可される。
+  // Codex も CODEX_BASE_URL + placeholder を使ってプロキシ経由、
+  // Gemini の直接注入のみ ALLOW_DIRECT_SECRET_INJECTION=true の明示オプトイン時に許可される。
   const sdkEnv: Record<string, string | undefined> = { ...process.env };
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -70,16 +70,17 @@ private_key, .secret
 
 **プロバイダーごとの方針:**
 - Anthropic / OpenAI: 常にプロキシ経由（コンテナへはプレースホルダーのみ）
-- Gemini / Codex: SDK 制約により直接注入が必要。`ALLOW_DIRECT_SECRET_INJECTION=true` の明示オプトインがある場合のみ許可し、未設定時は起動拒否
+- Codex: 常にプロキシ経由（`~/.codex/auth.json` をホスト側で解決し、Bearer を注入）
+- Gemini: SDK 制約により直接注入が必要。`ALLOW_DIRECT_SECRET_INJECTION=true` の明示オプトインがある場合のみ許可し、未設定時は起動拒否
 
-`ALLOW_DIRECT_SECRET_INJECTION=true` を有効化すると、`GEMINI_API_KEY` または `OAS_CODEX_OAUTH_JSON` がコンテナ環境変数として露出します。これは既定の隔離モデルを弱めるため、信頼境界と運用リスクを理解した場合にのみ使用してください。
+`ALLOW_DIRECT_SECRET_INJECTION=true` を有効化すると、`GEMINI_API_KEY` がコンテナ環境変数として露出します。これは既定の隔離モデルを弱めるため、信頼境界と運用リスクを理解した場合にのみ使用してください。
 
 **仕組み：**
 1. ホストが `CREDENTIAL_PROXY_PORT` (デフォルト: 3001) で認証情報プロキシを開始する
-2. Anthropic/OpenAI の場合、コンテナは `*_BASE_URL=http://host.docker.internal:<port>` と `*_API_KEY=placeholder` を受け取る
+2. Anthropic/OpenAI/Codex の場合、コンテナは `*_BASE_URL=http://host.docker.internal:<port>` と `*_API_KEY=placeholder` を受け取る（Codex は `CODEX_BASE_URL`/`CODEX_API_KEY`）
 3. SDK はプレースホルダーを使ってプロキシへ API リクエストを送信する
 4. プロキシはプレースホルダー認証情報を削除し、本物の認証情報 (`x-api-key` または `Authorization: Bearer`) を注入して上流 API に転送する
-5. Gemini/Codex は明示オプトイン時のみ直接注入を許可し、未オプトインでは起動を拒否する
+5. Gemini は明示オプトイン時のみ直接注入を許可し、未オプトインでは起動を拒否する
 
 **マウントされないもの：**
 - WhatsApp セッション (`store/auth/`) - ホストのみ

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.8.1",
-    "discord.js": "^14.18.0",
     "cron-parser": "^5.5.0",
+    "discord.js": "^14.18.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "yaml": "^2.8.2",

--- a/src/codex-oauth-test-helpers.ts
+++ b/src/codex-oauth-test-helpers.ts
@@ -1,0 +1,42 @@
+interface MakeCodexCliAuthJsonOptions {
+  expiresAtMs: number;
+  accountId?: string;
+  refreshToken?: string;
+}
+
+export function makeCodexAccessToken(
+  expiresAtMs: number,
+  accountId?: string,
+): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
+  ).toString('base64url');
+
+  const payloadObj: Record<string, unknown> = {
+    exp: Math.floor(expiresAtMs / 1000),
+  };
+
+  if (accountId) {
+    payloadObj['https://api.openai.com/auth'] = {
+      chatgpt_account_id: accountId,
+    };
+  }
+
+  const payload = Buffer.from(JSON.stringify(payloadObj)).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+export function makeCodexCliAuthJson(
+  options: MakeCodexCliAuthJsonOptions,
+): string {
+  const refreshToken = options.refreshToken || 'codex-refresh-token';
+
+  return JSON.stringify({
+    auth_mode: 'oauth',
+    tokens: {
+      access_token: makeCodexAccessToken(options.expiresAtMs, options.accountId),
+      refresh_token: refreshToken,
+      ...(options.accountId ? { account_id: options.accountId } : {}),
+    },
+  });
+}

--- a/src/codex-oauth-test-helpers.ts
+++ b/src/codex-oauth-test-helpers.ts
@@ -34,7 +34,10 @@ export function makeCodexCliAuthJson(
   return JSON.stringify({
     auth_mode: 'oauth',
     tokens: {
-      access_token: makeCodexAccessToken(options.expiresAtMs, options.accountId),
+      access_token: makeCodexAccessToken(
+        options.expiresAtMs,
+        options.accountId,
+      ),
       refresh_token: refreshToken,
       ...(options.accountId ? { account_id: options.accountId } : {}),
     },

--- a/src/codex-oauth.test.ts
+++ b/src/codex-oauth.test.ts
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __getCodexOAuthCacheKeysForTests,
+  __resetCodexOAuthCacheForTests,
+  __resolveCodexAuthFileWriteModeForTests,
+  resolveCodexOAuthApiKey,
+} from './codex-oauth.js';
+import { makeCodexAccessToken } from './codex-oauth-test-helpers.js';
+
+describe('codex-oauth', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-codex-oauth-'));
+    __resetCodexOAuthCacheForTests();
+  });
+
+  afterEach(() => {
+    __resetCodexOAuthCacheForTests();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses hashed oauth json cache keys and ignores formatting differences', async () => {
+    const expiredAccessToken = makeCodexAccessToken(
+      Date.now() - 60_000,
+      'acct_123',
+    );
+    const refreshedAccessToken = makeCodexAccessToken(
+      Date.now() + 3_600_000,
+      'acct_123',
+    );
+
+    const oauthObject = {
+      auth_mode: 'oauth',
+      tokens: {
+        access_token: expiredAccessToken,
+        refresh_token: 'refresh-token-shared',
+        account_id: 'acct_123',
+      },
+    };
+    const compactJson = JSON.stringify(oauthObject);
+    const prettyJson = JSON.stringify(oauthObject, null, 2);
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: refreshedAccessToken,
+          refresh_token: 'refresh-token-next',
+          expires_in: 3600,
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const first = await resolveCodexOAuthApiKey({ oauthJson: compactJson });
+    const second = await resolveCodexOAuthApiKey({ oauthJson: prettyJson });
+
+    expect(first.apiKey).toBe(refreshedAccessToken);
+    expect(second.apiKey).toBe(refreshedAccessToken);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const cacheKeys = __getCodexOAuthCacheKeysForTests();
+    expect(cacheKeys).toHaveLength(1);
+    expect(cacheKeys[0]).toMatch(/^oauth-json:[0-9a-f]{64}$/);
+    expect(cacheKeys[0]).not.toContain('refresh-token-shared');
+    expect(cacheKeys[0]).not.toContain(expiredAccessToken.slice(0, 12));
+  });
+
+  it('uses owner-only write mode defaults for auth file writes', () => {
+    const missingAuthPath = path.join(tempDir, 'missing-auth.json');
+    expect(__resolveCodexAuthFileWriteModeForTests(missingAuthPath)).toBe(
+      0o600,
+    );
+
+    const existingAuthPath = path.join(tempDir, 'existing-auth.json');
+    fs.writeFileSync(existingAuthPath, '{}');
+
+    fs.chmodSync(existingAuthPath, 0o644);
+    expect(__resolveCodexAuthFileWriteModeForTests(existingAuthPath)).toBe(
+      0o600,
+    );
+
+    fs.chmodSync(existingAuthPath, 0o400);
+    expect(__resolveCodexAuthFileWriteModeForTests(existingAuthPath)).toBe(
+      0o400,
+    );
+  });
+});

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -323,7 +323,9 @@ async function refreshCachedState(
   }
 
   const refreshPromise = (async () => {
-    const refreshed = await refreshCodexOAuthCredentials(cached.credentials.refresh);
+    const refreshed = await refreshCodexOAuthCredentials(
+      cached.credentials.refresh,
+    );
     cached.credentials = refreshed;
 
     if (cached.authPath && !cached.oauthJson) {

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -35,11 +36,14 @@ interface CodexOAuthSource {
   sourceKey: string;
   authPath?: string;
   oauthJson?: string;
+  parsedOauth?: ParsedCodexCliAuth;
 }
 
 interface CachedCodexState extends CodexOAuthSource {
   root: CodexCliAuthFile;
   credentials: CodexOAuthCredentials;
+  authFileFingerprint?: string;
+  authFileMode?: number;
 }
 
 export interface CodexOAuthCredentials {
@@ -182,13 +186,96 @@ function readCodexAuthFile(authPath: string): string {
   }
 }
 
+function buildCredentialsFingerprint(
+  credentials: CodexOAuthCredentials,
+): string {
+  const payload = JSON.stringify({
+    access: credentials.access,
+    refresh: credentials.refresh,
+    accountId: credentials.accountId || '',
+  });
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function normalizeOwnerOnlyFileMode(rawMode: number): number {
+  return rawMode & 0o600;
+}
+
+function buildAuthFileFingerprint(stats: fs.Stats): string {
+  return `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeMs}`;
+}
+
+function readCodexAuthFileSnapshot(authPath: string): {
+  fingerprint: string;
+  mode: number;
+} {
+  const resolvedPath = path.resolve(authPath);
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(resolvedPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') {
+      throw new CodexAuthFileNotFoundError(resolvedPath);
+    }
+    throw new Error(
+      `[codex-oauth] Failed to stat Codex auth file ${resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return {
+    fingerprint: buildAuthFileFingerprint(stats),
+    mode: normalizeOwnerOnlyFileMode(stats.mode & 0o777),
+  };
+}
+
+function resolveCodexAuthFileWriteMode(
+  authPath: string,
+  modeHint?: number,
+): number {
+  if (typeof modeHint === 'number') {
+    return normalizeOwnerOnlyFileMode(modeHint);
+  }
+
+  const resolvedPath = path.resolve(authPath);
+  try {
+    const stats = fs.statSync(resolvedPath);
+    return normalizeOwnerOnlyFileMode(stats.mode & 0o777);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') {
+      return 0o600;
+    }
+    throw new Error(
+      `[codex-oauth] Failed to stat Codex auth file ${resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function parseAuthFileAtPath(authPath: string): {
+  parsed: ParsedCodexCliAuth;
+  snapshot: { fingerprint: string; mode: number };
+} {
+  const snapshot = readCodexAuthFileSnapshot(authPath);
+  const raw = readCodexAuthFile(authPath);
+  const parsed = parseCodexOAuthJsonInput(raw, `Codex auth file (${authPath})`);
+
+  return { parsed, snapshot };
+}
+
 function resolveSource(
   options: ResolveCodexOAuthApiKeyOptions,
 ): CodexOAuthSource {
   if (options.oauthJson) {
+    const parsedOauth = parseCodexOAuthJsonInput(
+      options.oauthJson,
+      'OAS_CODEX_OAUTH_JSON',
+    );
     return {
-      sourceKey: `oauth-json:${options.oauthJson}`,
+      sourceKey: `oauth-json:${buildCredentialsFingerprint(parsedOauth.credentials)}`,
       oauthJson: options.oauthJson,
+      parsedOauth,
     };
   }
 
@@ -207,13 +294,13 @@ function resolveSource(
 
 function loadCachedState(source: CodexOAuthSource): CachedCodexState {
   if (source.oauthJson) {
-    const parsed = parseCodexOAuthJsonInput(
-      source.oauthJson,
-      'OAS_CODEX_OAUTH_JSON',
-    );
+    const parsed =
+      source.parsedOauth ||
+      parseCodexOAuthJsonInput(source.oauthJson, 'OAS_CODEX_OAUTH_JSON');
 
     return {
-      ...source,
+      sourceKey: source.sourceKey,
+      oauthJson: source.oauthJson,
       root: parsed.root,
       credentials: parsed.credentials,
     };
@@ -225,16 +312,15 @@ function loadCachedState(source: CodexOAuthSource): CachedCodexState {
     );
   }
 
-  const raw = readCodexAuthFile(source.authPath);
-  const parsed = parseCodexOAuthJsonInput(
-    raw,
-    `Codex auth file (${source.authPath})`,
-  );
+  const { parsed, snapshot } = parseAuthFileAtPath(source.authPath);
 
   return {
-    ...source,
+    sourceKey: source.sourceKey,
+    authPath: source.authPath,
     root: parsed.root,
     credentials: parsed.credentials,
+    authFileFingerprint: snapshot.fingerprint,
+    authFileMode: snapshot.mode,
   };
 }
 
@@ -266,10 +352,15 @@ function serializeCodexCliAuth(
   return JSON.stringify(updated, null, 2) + '\n';
 }
 
-function writeCodexAuthFileAtomic(authPath: string, contents: string): void {
+function writeCodexAuthFileAtomic(
+  authPath: string,
+  contents: string,
+  modeHint?: number,
+): void {
   const resolvedPath = path.resolve(authPath);
   const dirPath = path.dirname(resolvedPath);
   const baseName = path.basename(resolvedPath);
+  const writeMode = resolveCodexAuthFileWriteMode(resolvedPath, modeHint);
   const tempPath = path.join(
     dirPath,
     `.${baseName}.${process.pid}.${Date.now().toString(36)}.${Math.random().toString(16).slice(2)}.tmp`,
@@ -277,9 +368,13 @@ function writeCodexAuthFileAtomic(authPath: string, contents: string): void {
 
   let tempCreated = false;
   try {
-    fs.writeFileSync(tempPath, contents, 'utf-8');
+    fs.writeFileSync(tempPath, contents, {
+      encoding: 'utf-8',
+      mode: writeMode,
+    });
     tempCreated = true;
     fs.renameSync(tempPath, resolvedPath);
+    fs.chmodSync(resolvedPath, writeMode);
   } catch (err) {
     if (tempCreated || fs.existsSync(tempPath)) {
       try {
@@ -290,6 +385,36 @@ function writeCodexAuthFileAtomic(authPath: string, contents: string): void {
     }
     throw err;
   }
+}
+
+function maybeReloadCachedAuthFileIfChanged(cached: CachedCodexState): void {
+  if (!cached.authPath || cached.oauthJson) {
+    return;
+  }
+
+  const snapshot = readCodexAuthFileSnapshot(cached.authPath);
+  if (cached.authFileFingerprint === snapshot.fingerprint) {
+    cached.authFileMode = snapshot.mode;
+    return;
+  }
+
+  const { parsed } = parseAuthFileAtPath(cached.authPath);
+  cached.root = parsed.root;
+  cached.credentials = parsed.credentials;
+  cached.authFileFingerprint = snapshot.fingerprint;
+  cached.authFileMode = snapshot.mode;
+}
+
+function forceReloadCachedAuthFile(cached: CachedCodexState): void {
+  if (!cached.authPath || cached.oauthJson) {
+    return;
+  }
+
+  const { parsed, snapshot } = parseAuthFileAtPath(cached.authPath);
+  cached.root = parsed.root;
+  cached.credentials = parsed.credentials;
+  cached.authFileFingerprint = snapshot.fingerprint;
+  cached.authFileMode = snapshot.mode;
 }
 
 function shouldRefresh(credentials: CodexOAuthCredentials): boolean {
@@ -366,7 +491,14 @@ async function refreshCachedState(
 
     if (cached.authPath && !cached.oauthJson) {
       const serialized = serializeCodexCliAuth(cached.root, refreshed);
-      writeCodexAuthFileAtomic(cached.authPath, serialized);
+      writeCodexAuthFileAtomic(
+        cached.authPath,
+        serialized,
+        cached.authFileMode,
+      );
+      const snapshot = readCodexAuthFileSnapshot(cached.authPath);
+      cached.authFileFingerprint = snapshot.fingerprint;
+      cached.authFileMode = snapshot.mode;
     }
 
     return refreshed;
@@ -400,8 +532,21 @@ export async function resolveCodexOAuthApiKey(
   const source = resolveSource(options);
   const cached = getOrLoadCachedState(source);
 
+  maybeReloadCachedAuthFileIfChanged(cached);
+
   if (shouldRefresh(cached.credentials)) {
-    await refreshCachedState(cached);
+    try {
+      await refreshCachedState(cached);
+    } catch (err) {
+      if (!cached.authPath || cached.oauthJson) {
+        throw err;
+      }
+
+      forceReloadCachedAuthFile(cached);
+      if (shouldRefresh(cached.credentials)) {
+        await refreshCachedState(cached);
+      }
+    }
   }
 
   return {
@@ -413,4 +558,14 @@ export async function resolveCodexOAuthApiKey(
 export function __resetCodexOAuthCacheForTests(): void {
   cachedCodexStateBySource.clear();
   refreshInFlightBySource.clear();
+}
+
+export function __getCodexOAuthCacheKeysForTests(): string[] {
+  return [...cachedCodexStateBySource.keys()];
+}
+
+export function __resolveCodexAuthFileWriteModeForTests(
+  authPath: string,
+): number {
+  return resolveCodexAuthFileWriteMode(authPath);
 }

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -1,0 +1,378 @@
+import fs from 'fs';
+import path from 'path';
+
+const OPENAI_CODEX_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const EXPIRY_SKEW_MS = 30_000;
+
+interface CodexCliAuthFile {
+  auth_mode?: string;
+  tokens?: {
+    access_token?: string;
+    refresh_token?: string;
+    account_id?: string;
+  };
+}
+
+interface ParsedCodexCliAuth {
+  root: CodexCliAuthFile;
+  credentials: CodexOAuthCredentials;
+}
+
+interface CodexOAuthSource {
+  sourceKey: string;
+  authPath?: string;
+  oauthJson?: string;
+}
+
+interface CachedCodexState extends CodexOAuthSource {
+  root: CodexCliAuthFile;
+  credentials: CodexOAuthCredentials;
+}
+
+export interface CodexOAuthCredentials {
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+}
+
+export interface ResolveCodexOAuthApiKeyOptions {
+  authPath?: string;
+  oauthJson?: string;
+}
+
+export interface ResolveCodexOAuthApiKeyResult {
+  apiKey: string;
+  credentials: CodexOAuthCredentials;
+}
+
+const cachedCodexStateBySource = new Map<string, CachedCodexState>();
+const refreshInFlightBySource = new Map<
+  string,
+  Promise<CodexOAuthCredentials>
+>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
+  const parts = token.split('.');
+  if (parts.length !== 3) return undefined;
+
+  try {
+    return JSON.parse(
+      Buffer.from(parts[1] ?? '', 'base64url').toString('utf8'),
+    ) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function getExpiryFromJwt(token: string): number | undefined {
+  const payload = decodeJwtPayload(token);
+  const exp = payload?.exp;
+  return typeof exp === 'number' ? exp * 1000 : undefined;
+}
+
+function getAccountIdFromJwt(token: string): string | undefined {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return undefined;
+
+  const authClaim = payload['https://api.openai.com/auth'];
+  if (!isRecord(authClaim)) return undefined;
+
+  const accountId = authClaim.chatgpt_account_id;
+  return typeof accountId === 'string' && accountId.length > 0
+    ? accountId
+    : undefined;
+}
+
+function parseCodexCliAuth(
+  value: unknown,
+  sourceLabel: string,
+): ParsedCodexCliAuth {
+  if (!isRecord(value)) {
+    throw new Error(
+      `[codex-oauth] ${sourceLabel} must be Codex CLI auth JSON (object).`,
+    );
+  }
+
+  const root = value as CodexCliAuthFile;
+  const tokens = root.tokens;
+  if (!isRecord(tokens)) {
+    throw new Error(
+      `[codex-oauth] ${sourceLabel} must contain tokens.access_token and tokens.refresh_token.`,
+    );
+  }
+
+  const access = tokens.access_token;
+  const refresh = tokens.refresh_token;
+  if (typeof access !== 'string' || typeof refresh !== 'string') {
+    throw new Error(
+      `[codex-oauth] ${sourceLabel} must contain tokens.access_token and tokens.refresh_token.`,
+    );
+  }
+
+  const expires = getExpiryFromJwt(access);
+  if (typeof expires !== 'number') {
+    throw new Error(
+      `[codex-oauth] ${sourceLabel} has invalid access_token (missing JWT exp claim).`,
+    );
+  }
+
+  const accountId =
+    typeof tokens.account_id === 'string'
+      ? tokens.account_id
+      : getAccountIdFromJwt(access);
+
+  return {
+    root,
+    credentials: {
+      access,
+      refresh,
+      expires,
+      ...(accountId ? { accountId } : {}),
+    },
+  };
+}
+
+function parseCodexOAuthJsonInput(
+  jsonText: string,
+  sourceLabel: string,
+): ParsedCodexCliAuth {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new Error(
+      `[codex-oauth] ${sourceLabel} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return parseCodexCliAuth(parsed, sourceLabel);
+}
+
+function readCodexAuthFile(authPath: string): string {
+  const resolvedPath = path.resolve(authPath);
+
+  try {
+    return fs.readFileSync(resolvedPath, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') {
+      throw new Error(
+        `[codex-oauth] Codex auth file was not found: ${resolvedPath}. Run "codex login" or set OAS_CODEX_AUTH_PATH.`,
+      );
+    }
+    throw new Error(
+      `[codex-oauth] Failed to read Codex auth file ${resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function resolveSource(
+  options: ResolveCodexOAuthApiKeyOptions,
+): CodexOAuthSource {
+  if (options.oauthJson) {
+    return {
+      sourceKey: `oauth-json:${options.oauthJson}`,
+      oauthJson: options.oauthJson,
+    };
+  }
+
+  if (options.authPath) {
+    const resolvedPath = path.resolve(options.authPath);
+    return {
+      sourceKey: `auth-path:${resolvedPath}`,
+      authPath: resolvedPath,
+    };
+  }
+
+  throw new Error(
+    '[codex-oauth] No Codex OAuth source configured. Set OAS_CODEX_AUTH_PATH or OAS_CODEX_OAUTH_JSON.',
+  );
+}
+
+function loadCachedState(source: CodexOAuthSource): CachedCodexState {
+  if (source.oauthJson) {
+    const parsed = parseCodexOAuthJsonInput(
+      source.oauthJson,
+      'OAS_CODEX_OAUTH_JSON',
+    );
+
+    return {
+      ...source,
+      root: parsed.root,
+      credentials: parsed.credentials,
+    };
+  }
+
+  if (!source.authPath) {
+    throw new Error(
+      '[codex-oauth] No Codex auth path configured. Set OAS_CODEX_AUTH_PATH.',
+    );
+  }
+
+  const raw = readCodexAuthFile(source.authPath);
+  const parsed = parseCodexOAuthJsonInput(
+    raw,
+    `Codex auth file (${source.authPath})`,
+  );
+
+  return {
+    ...source,
+    root: parsed.root,
+    credentials: parsed.credentials,
+  };
+}
+
+function getOrLoadCachedState(source: CodexOAuthSource): CachedCodexState {
+  const cached = cachedCodexStateBySource.get(source.sourceKey);
+  if (cached) {
+    return cached;
+  }
+
+  const loaded = loadCachedState(source);
+  cachedCodexStateBySource.set(source.sourceKey, loaded);
+  return loaded;
+}
+
+function serializeCodexCliAuth(
+  root: CodexCliAuthFile,
+  credentials: CodexOAuthCredentials,
+): string {
+  const tokens = isRecord(root.tokens) ? root.tokens : {};
+  const updated: CodexCliAuthFile = {
+    ...root,
+    tokens: {
+      ...tokens,
+      access_token: credentials.access,
+      refresh_token: credentials.refresh,
+      ...(credentials.accountId ? { account_id: credentials.accountId } : {}),
+    },
+  };
+  return JSON.stringify(updated, null, 2) + '\n';
+}
+
+function shouldRefresh(credentials: CodexOAuthCredentials): boolean {
+  return Date.now() + EXPIRY_SKEW_MS >= credentials.expires;
+}
+
+async function refreshCodexOAuthCredentials(
+  refreshToken: string,
+): Promise<CodexOAuthCredentials> {
+  let response: Response;
+  try {
+    response = await fetch(OPENAI_CODEX_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: OPENAI_CODEX_CLIENT_ID,
+      }),
+    });
+  } catch (err) {
+    throw new Error(
+      `[codex-oauth] Failed to refresh OpenAI Codex OAuth token: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `[codex-oauth] OpenAI Codex OAuth refresh failed with status ${response.status}${body ? `: ${body}` : ''}`,
+    );
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+  const accessToken = json.access_token;
+  const nextRefreshToken = json.refresh_token;
+  const expiresIn = json.expires_in;
+
+  if (
+    typeof accessToken !== 'string' ||
+    typeof nextRefreshToken !== 'string' ||
+    typeof expiresIn !== 'number'
+  ) {
+    throw new Error(
+      '[codex-oauth] OpenAI Codex OAuth refresh response is missing required fields.',
+    );
+  }
+
+  const accountId = getAccountIdFromJwt(accessToken);
+
+  return {
+    access: accessToken,
+    refresh: nextRefreshToken,
+    expires: Date.now() + expiresIn * 1000,
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+async function refreshCachedState(
+  cached: CachedCodexState,
+): Promise<CodexOAuthCredentials> {
+  const existing = refreshInFlightBySource.get(cached.sourceKey);
+  if (existing) {
+    return await existing;
+  }
+
+  const refreshPromise = (async () => {
+    const refreshed = await refreshCodexOAuthCredentials(cached.credentials.refresh);
+    cached.credentials = refreshed;
+
+    if (cached.authPath && !cached.oauthJson) {
+      const serialized = serializeCodexCliAuth(cached.root, refreshed);
+      fs.writeFileSync(cached.authPath, serialized, 'utf-8');
+    }
+
+    return refreshed;
+  })();
+
+  refreshInFlightBySource.set(cached.sourceKey, refreshPromise);
+
+  try {
+    return await refreshPromise;
+  } finally {
+    if (refreshInFlightBySource.get(cached.sourceKey) === refreshPromise) {
+      refreshInFlightBySource.delete(cached.sourceKey);
+    }
+  }
+}
+
+export function validateCodexOAuthJson(oauthJson: string): void {
+  parseCodexOAuthJsonInput(oauthJson, 'OAS_CODEX_OAUTH_JSON');
+}
+
+export function validateCodexAuthFile(authPath: string): void {
+  const resolvedPath = path.resolve(authPath);
+  const raw = readCodexAuthFile(resolvedPath);
+
+  parseCodexOAuthJsonInput(raw, `Codex auth file (${resolvedPath})`);
+}
+
+export async function resolveCodexOAuthApiKey(
+  options: ResolveCodexOAuthApiKeyOptions,
+): Promise<ResolveCodexOAuthApiKeyResult> {
+  const source = resolveSource(options);
+  const cached = getOrLoadCachedState(source);
+
+  if (shouldRefresh(cached.credentials)) {
+    await refreshCachedState(cached);
+  }
+
+  return {
+    apiKey: cached.credentials.access,
+    credentials: cached.credentials,
+  };
+}
+
+export function __resetCodexOAuthCacheForTests(): void {
+  cachedCodexStateBySource.clear();
+  refreshInFlightBySource.clear();
+}

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -5,6 +5,18 @@ const OPENAI_CODEX_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const EXPIRY_SKEW_MS = 30_000;
 
+export class CodexAuthFileNotFoundError extends Error {
+  readonly authPath: string;
+
+  constructor(authPath: string) {
+    super(
+      `[codex-oauth] Codex auth file was not found: ${authPath}. Run "codex login" or set OAS_CODEX_AUTH_PATH.`,
+    );
+    this.name = 'CodexAuthFileNotFoundError';
+    this.authPath = authPath;
+  }
+}
+
 interface CodexCliAuthFile {
   auth_mode?: string;
   tokens?: {
@@ -162,9 +174,7 @@ function readCodexAuthFile(authPath: string): string {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException | undefined)?.code;
     if (code === 'ENOENT') {
-      throw new Error(
-        `[codex-oauth] Codex auth file was not found: ${resolvedPath}. Run "codex login" or set OAS_CODEX_AUTH_PATH.`,
-      );
+      throw new CodexAuthFileNotFoundError(resolvedPath);
     }
     throw new Error(
       `[codex-oauth] Failed to read Codex auth file ${resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
@@ -256,6 +266,32 @@ function serializeCodexCliAuth(
   return JSON.stringify(updated, null, 2) + '\n';
 }
 
+function writeCodexAuthFileAtomic(authPath: string, contents: string): void {
+  const resolvedPath = path.resolve(authPath);
+  const dirPath = path.dirname(resolvedPath);
+  const baseName = path.basename(resolvedPath);
+  const tempPath = path.join(
+    dirPath,
+    `.${baseName}.${process.pid}.${Date.now().toString(36)}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+
+  let tempCreated = false;
+  try {
+    fs.writeFileSync(tempPath, contents, 'utf-8');
+    tempCreated = true;
+    fs.renameSync(tempPath, resolvedPath);
+  } catch (err) {
+    if (tempCreated || fs.existsSync(tempPath)) {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {
+        // noop: best-effort cleanup only
+      }
+    }
+    throw err;
+  }
+}
+
 function shouldRefresh(credentials: CodexOAuthCredentials): boolean {
   return Date.now() + EXPIRY_SKEW_MS >= credentials.expires;
 }
@@ -330,7 +366,7 @@ async function refreshCachedState(
 
     if (cached.authPath && !cached.oauthJson) {
       const serialized = serializeCodexCliAuth(cached.root, refreshed);
-      fs.writeFileSync(cached.authPath, serialized, 'utf-8');
+      writeCodexAuthFileAtomic(cached.authPath, serialized);
     }
 
     return refreshed;

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -382,12 +382,13 @@ describe('container-runner timeout behavior', () => {
     expect(joined).not.toContain('ANTHROPIC_BASE_URL=');
   });
 
-  it('injects Codex oauth json when provider env mapping switches', async () => {
+  it('injects Codex proxy env when provider env mapping switches', async () => {
     for (const key of Object.keys(mockContainerProviderEnv)) {
       delete mockContainerProviderEnv[key];
     }
     Object.assign(mockContainerProviderEnv, {
-      OAS_CODEX_OAUTH_JSON: '{"access":"a","refresh":"r","expires":1}',
+      CODEX_BASE_URL: 'http://host.docker.internal:3001',
+      CODEX_API_KEY: 'placeholder',
     });
 
     const resultPromise = runContainerAgent(testGroup, testInput, () => {});
@@ -404,9 +405,8 @@ describe('container-runner timeout behavior', () => {
     const spawnCalls = vi.mocked(spawn).mock.calls;
     const args = spawnCalls[spawnCalls.length - 1][1] as string[];
     const joined = args.join(' ');
-    expect(joined).toContain(
-      '-e OAS_CODEX_OAUTH_JSON={"access":"a","refresh":"r","expires":1}',
-    );
+    expect(joined).toContain('-e CODEX_BASE_URL=http://host.docker.internal:3001');
+    expect(joined).toContain('-e CODEX_API_KEY=placeholder');
     expect(joined).not.toContain('OPENAI_BASE_URL=');
     expect(joined).not.toContain('ANTHROPIC_BASE_URL=');
   });

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -405,7 +405,9 @@ describe('container-runner timeout behavior', () => {
     const spawnCalls = vi.mocked(spawn).mock.calls;
     const args = spawnCalls[spawnCalls.length - 1][1] as string[];
     const joined = args.join(' ');
-    expect(joined).toContain('-e CODEX_BASE_URL=http://host.docker.internal:3001');
+    expect(joined).toContain(
+      '-e CODEX_BASE_URL=http://host.docker.internal:3001',
+    );
     expect(joined).toContain('-e CODEX_API_KEY=placeholder');
     expect(joined).not.toContain('OPENAI_BASE_URL=');
     expect(joined).not.toContain('ANTHROPIC_BASE_URL=');

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -301,7 +301,7 @@ function buildContainerArgs(
 
   // プロバイダーごとに必要な環境変数のみを注入する。
   // Anthropic/OpenAI はプロキシ + placeholder、Gemini は直接キー注入、
-  // Codex は OAuth JSON を渡してコンテナ側で codexOAuth を構築する。
+  // Codex は CODEX_BASE_URL + placeholder でプロキシ経由に統一する。
   for (const [key, value] of Object.entries(providerEnv)) {
     args.push('-e', `${key}=${value}`);
   }

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import fs from 'fs';
 import http from 'http';
 import type { AddressInfo } from 'net';
+
+const originalCodexHome = process.env.CODEX_HOME;
 
 const mockEnv: Record<string, string> = {};
 vi.mock('./env.js', () => ({
@@ -12,6 +15,11 @@ vi.mock('./logger.js', () => ({
 }));
 
 import { startCredentialProxy } from './credential-proxy.js';
+import { __resetCodexOAuthCacheForTests } from './codex-oauth.js';
+import {
+  makeCodexAccessToken,
+  makeCodexCliAuthJson,
+} from './codex-oauth-test-helpers.js';
 
 function makeRequest(
   port: number,
@@ -96,6 +104,7 @@ describe('credential-proxy', () => {
   ) => void;
 
   beforeEach(async () => {
+    process.env.CODEX_HOME = '/tmp/nanoclaw-credential-proxy-tests';
     lastUpstreamHeaders = {};
     upstreamHandler = (req, res) => {
       lastUpstreamHeaders = { ...req.headers };
@@ -121,7 +130,18 @@ describe('credential-proxy', () => {
       await new Promise<void>((r) => upstreamServer!.close(() => r()));
       upstreamServer = undefined;
     }
+    __resetCodexOAuthCacheForTests();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  });
+
+  afterAll(() => {
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
+    }
   });
 
   async function startProxy(env: Record<string, string>): Promise<number> {
@@ -130,6 +150,12 @@ describe('credential-proxy', () => {
       mergedEnv.ANTHROPIC_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
     }
     if (mergedEnv.OPENAI_API_KEY && !mergedEnv.OPENAI_BASE_URL) {
+      mergedEnv.OPENAI_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
+    }
+    if (
+      (mergedEnv.OAS_CODEX_OAUTH_JSON || mergedEnv.OAS_CODEX_AUTH_PATH) &&
+      !mergedEnv.OPENAI_BASE_URL
+    ) {
       mergedEnv.OPENAI_BASE_URL = `http://127.0.0.1:${upstreamPort}`;
     }
 
@@ -220,24 +246,187 @@ describe('credential-proxy', () => {
     expect(res.body).toContain('disabled');
   });
 
-  it('returns 503 in disabled mode for codex oauth provider', async () => {
+  it('codex mode replaces Authorization with Bearer oauth access token', async () => {
+    const accessToken = makeCodexAccessToken(Date.now() + 60_000, 'acct_123');
     proxyPort = await startProxy({
-      OAS_CODEX_OAUTH_JSON: '{"access":"a","refresh":"r","expires":1}',
-      ALLOW_DIRECT_SECRET_INJECTION: 'true',
+      OAS_CODEX_OAUTH_JSON: JSON.stringify({
+        auth_mode: 'oauth',
+        tokens: {
+          access_token: accessToken,
+          refresh_token: 'codex-refresh-token',
+          account_id: 'acct_123',
+        },
+      }),
     });
 
-    const res = await makeRequest(
+    await makeRequest(
       proxyPort,
       {
         method: 'POST',
-        path: '/v1/messages',
-        headers: { 'content-type': 'application/json' },
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
       },
       '{}',
     );
 
-    expect(res.statusCode).toBe(503);
-    expect(res.body).toContain('disabled');
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      `Bearer ${accessToken}`,
+    );
+  });
+
+  it('codex mode refreshes expired token once and reuses refreshed credentials', async () => {
+    const refreshedAccessToken = makeCodexAccessToken(
+      Date.now() + 3_600_000,
+      'acct_123',
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: refreshedAccessToken,
+          refresh_token: 'codex-refreshed-refresh',
+          expires_in: 3600,
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+
+    const codexAuthPath =
+      `/tmp/nanoclaw-codex-auth-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+    fs.writeFileSync(
+      codexAuthPath,
+      makeCodexCliAuthJson({
+        expiresAtMs: Date.now() - 60_000,
+        accountId: 'acct_123',
+      }),
+    );
+
+    proxyPort = await startProxy({
+      OAS_CODEX_AUTH_PATH: codexAuthPath,
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      `Bearer ${refreshedAccessToken}`,
+    );
+    const readsAfterFirstRequest = readSpy.mock.calls.filter(
+      ([filePath]) => String(filePath) === codexAuthPath,
+    ).length;
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const readsAfterSecondRequest = readSpy.mock.calls.filter(
+      ([filePath]) => String(filePath) === codexAuthPath,
+    ).length;
+    expect(readsAfterSecondRequest).toBe(readsAfterFirstRequest);
+  });
+
+  it('codex mode deduplicates concurrent refresh calls', async () => {
+    const refreshedAccessToken = makeCodexAccessToken(
+      Date.now() + 3_600_000,
+      'acct_123',
+    );
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return new Response(
+        JSON.stringify({
+          access_token: refreshedAccessToken,
+          refresh_token: 'codex-refreshed-refresh',
+          expires_in: 3600,
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const codexAuthPath =
+      `/tmp/nanoclaw-codex-auth-concurrent-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+    fs.writeFileSync(
+      codexAuthPath,
+      makeCodexCliAuthJson({
+        expiresAtMs: Date.now() - 60_000,
+        accountId: 'acct_123',
+      }),
+    );
+
+    proxyPort = await startProxy({
+      OAS_CODEX_AUTH_PATH: codexAuthPath,
+    });
+
+    await Promise.all([
+      makeRequest(
+        proxyPort,
+        {
+          method: 'POST',
+          path: '/v1/responses',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer placeholder',
+          },
+        },
+        '{}',
+      ),
+      makeRequest(
+        proxyPort,
+        {
+          method: 'POST',
+          path: '/v1/responses',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer placeholder',
+          },
+        },
+        '{}',
+      ),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws clear error when codex auth file is missing', () => {
+    Object.assign(mockEnv, {
+      OAS_CODEX_AUTH_PATH: '/tmp/nanoclaw-missing-codex-auth.json',
+      OPENAI_BASE_URL: `http://127.0.0.1:${upstreamPort}`,
+    });
+
+    expect(() => startCredentialProxy(0)).toThrow(
+      'Codex auth file was not found',
+    );
   });
 
   it('throws when no supported provider key is configured', () => {

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -1,14 +1,8 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  afterAll,
-  vi,
-} from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import http from 'http';
+import os from 'os';
+import path from 'path';
 import type { AddressInfo } from 'net';
 
 const originalCodexHome = process.env.CODEX_HOME;
@@ -105,6 +99,7 @@ describe('credential-proxy', () => {
   let upstreamServer: http.Server | undefined;
   let proxyPort: number;
   let upstreamPort: number;
+  let tempDir: string;
   let lastUpstreamHeaders: http.IncomingHttpHeaders;
   let upstreamHandler: (
     req: http.IncomingMessage,
@@ -112,7 +107,10 @@ describe('credential-proxy', () => {
   ) => void;
 
   beforeEach(async () => {
-    process.env.CODEX_HOME = '/tmp/nanoclaw-credential-proxy-tests';
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'nanoclaw-credential-proxy-tests-'),
+    );
+    process.env.CODEX_HOME = tempDir;
     lastUpstreamHeaders = {};
     upstreamHandler = (req, res) => {
       lastUpstreamHeaders = { ...req.headers };
@@ -141,16 +139,21 @@ describe('credential-proxy', () => {
     __resetCodexOAuthCacheForTests();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
-    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
-  });
-
-  afterAll(() => {
     if (originalCodexHome === undefined) {
       delete process.env.CODEX_HOME;
     } else {
       process.env.CODEX_HOME = originalCodexHome;
     }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
   });
+
+  function createTempCodexAuthPath(namePrefix: string): string {
+    return path.join(
+      tempDir,
+      `${namePrefix}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
+    );
+  }
 
   async function startProxy(env: Record<string, string>): Promise<number> {
     const mergedEnv = { ...env };
@@ -303,8 +306,10 @@ describe('credential-proxy', () => {
     );
     vi.stubGlobal('fetch', fetchMock as typeof fetch);
     const readSpy = vi.spyOn(fs, 'readFileSync');
+    const writeSpy = vi.spyOn(fs, 'writeFileSync');
+    const renameSpy = vi.spyOn(fs, 'renameSync');
 
-    const codexAuthPath = `/tmp/nanoclaw-codex-auth-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+    const codexAuthPath = createTempCodexAuthPath('nanoclaw-codex-auth');
     fs.writeFileSync(
       codexAuthPath,
       makeCodexCliAuthJson({
@@ -334,6 +339,22 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['authorization']).toBe(
       `Bearer ${refreshedAccessToken}`,
     );
+    const refreshWriteCalls = writeSpy.mock.calls.filter(([, contents]) =>
+      typeof contents === 'string'
+        ? contents.includes('codex-refreshed-refresh')
+        : false,
+    );
+    expect(refreshWriteCalls).toHaveLength(1);
+    const atomicTempPath = String(refreshWriteCalls[0]?.[0]);
+    expect(atomicTempPath).not.toBe(codexAuthPath);
+    expect(path.dirname(atomicTempPath)).toBe(path.dirname(codexAuthPath));
+    expect(renameSpy).toHaveBeenCalledWith(atomicTempPath, codexAuthPath);
+    expect(
+      fs
+        .readdirSync(path.dirname(codexAuthPath))
+        .filter((name) => name.endsWith('.tmp')),
+    ).toEqual([]);
+
     const readsAfterFirstRequest = readSpy.mock.calls.filter(
       ([filePath]) => String(filePath) === codexAuthPath,
     ).length;
@@ -379,7 +400,9 @@ describe('credential-proxy', () => {
     });
     vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
-    const codexAuthPath = `/tmp/nanoclaw-codex-auth-concurrent-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+    const codexAuthPath = createTempCodexAuthPath(
+      'nanoclaw-codex-auth-concurrent',
+    );
     fs.writeFileSync(
       codexAuthPath,
       makeCodexCliAuthJson({
@@ -420,6 +443,39 @@ describe('credential-proxy', () => {
     ]);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns generic 500 without leaking host details on codex resolve failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(
+        new Error('network timeout reading /Users/shin/.codex/auth.json'),
+      );
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    proxyPort = await startProxy({
+      OAS_CODEX_OAUTH_JSON: makeCodexCliAuthJson({
+        expiresAtMs: Date.now() - 60_000,
+        accountId: 'acct_123',
+      }),
+    });
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toBe('Credential proxy credential resolution failed.');
+    expect(res.body).not.toContain('/Users/shin');
   });
 
   it('throws clear error when codex auth file is missing', () => {

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  vi,
+} from 'vitest';
 import fs from 'fs';
 import http from 'http';
 import type { AddressInfo } from 'net';
@@ -272,9 +280,7 @@ describe('credential-proxy', () => {
       '{}',
     );
 
-    expect(lastUpstreamHeaders['authorization']).toBe(
-      `Bearer ${accessToken}`,
-    );
+    expect(lastUpstreamHeaders['authorization']).toBe(`Bearer ${accessToken}`);
   });
 
   it('codex mode refreshes expired token once and reuses refreshed credentials', async () => {
@@ -298,8 +304,7 @@ describe('credential-proxy', () => {
     vi.stubGlobal('fetch', fetchMock as typeof fetch);
     const readSpy = vi.spyOn(fs, 'readFileSync');
 
-    const codexAuthPath =
-      `/tmp/nanoclaw-codex-auth-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+    const codexAuthPath = `/tmp/nanoclaw-codex-auth-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
     fs.writeFileSync(
       codexAuthPath,
       makeCodexCliAuthJson({
@@ -374,8 +379,7 @@ describe('credential-proxy', () => {
     });
     vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
-    const codexAuthPath =
-      `/tmp/nanoclaw-codex-auth-concurrent-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+    const codexAuthPath = `/tmp/nanoclaw-codex-auth-concurrent-${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
     fs.writeFileSync(
       codexAuthPath,
       makeCodexCliAuthJson({

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -286,6 +286,85 @@ describe('credential-proxy', () => {
     expect(lastUpstreamHeaders['authorization']).toBe(`Bearer ${accessToken}`);
   });
 
+  it('codex mode reloads auth file updates without restarting proxy', async () => {
+    const firstAccessToken = makeCodexAccessToken(
+      Date.now() + 120_000,
+      'acct_123',
+    );
+    const secondAccessToken = makeCodexAccessToken(
+      Date.now() + 240_000,
+      'acct_123',
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const codexAuthPath = createTempCodexAuthPath(
+      'nanoclaw-codex-auth-file-update',
+    );
+    fs.writeFileSync(
+      codexAuthPath,
+      JSON.stringify({
+        auth_mode: 'oauth',
+        tokens: {
+          access_token: firstAccessToken,
+          refresh_token: 'refresh-token-a',
+          account_id: 'acct_123',
+        },
+      }),
+    );
+
+    proxyPort = await startProxy({
+      OAS_CODEX_AUTH_PATH: codexAuthPath,
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      `Bearer ${firstAccessToken}`,
+    );
+
+    fs.writeFileSync(
+      codexAuthPath,
+      JSON.stringify({
+        auth_mode: 'oauth',
+        tokens: {
+          access_token: secondAccessToken,
+          refresh_token: 'refresh-token-updated-b-longer',
+          account_id: 'acct_123',
+        },
+      }),
+    );
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      `Bearer ${secondAccessToken}`,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('codex mode refreshes expired token once and reuses refreshed credentials', async () => {
     const refreshedAccessToken = makeCodexAccessToken(
       Date.now() + 3_600_000,
@@ -317,6 +396,7 @@ describe('credential-proxy', () => {
         accountId: 'acct_123',
       }),
     );
+    fs.chmodSync(codexAuthPath, 0o644);
 
     proxyPort = await startProxy({
       OAS_CODEX_AUTH_PATH: codexAuthPath,
@@ -377,6 +457,89 @@ describe('credential-proxy', () => {
       ([filePath]) => String(filePath) === codexAuthPath,
     ).length;
     expect(readsAfterSecondRequest).toBe(readsAfterFirstRequest);
+
+    const authFileMode = fs.statSync(codexAuthPath).mode & 0o777;
+    expect(authFileMode).toBe(0o600);
+  });
+
+  it('codex mode retries refresh with reloaded auth file when initial refresh fails', async () => {
+    const refreshedAccessToken = makeCodexAccessToken(
+      Date.now() + 3_600_000,
+      'acct_123',
+    );
+    const codexAuthPath = createTempCodexAuthPath(
+      'nanoclaw-codex-auth-refresh-retry',
+    );
+    fs.writeFileSync(
+      codexAuthPath,
+      makeCodexCliAuthJson({
+        expiresAtMs: Date.now() - 60_000,
+        accountId: 'acct_123',
+        refreshToken: 'stale-refresh-token',
+      }),
+    );
+
+    const refreshBodies: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+      const body =
+        init?.body instanceof URLSearchParams
+          ? init.body.toString()
+          : String(init?.body || '');
+      refreshBodies.push(body);
+
+      if (body.includes('refresh_token=stale-refresh-token')) {
+        fs.writeFileSync(
+          codexAuthPath,
+          makeCodexCliAuthJson({
+            expiresAtMs: Date.now() - 30_000,
+            accountId: 'acct_123',
+            refreshToken: 'fresh-refresh-token',
+          }),
+        );
+        return new Response('invalid_grant', { status: 400 });
+      }
+
+      if (body.includes('refresh_token=fresh-refresh-token')) {
+        return new Response(
+          JSON.stringify({
+            access_token: refreshedAccessToken,
+            refresh_token: 'fresh-refresh-token-next',
+            expires_in: 3600,
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+      }
+
+      return new Response('unexpected refresh token', { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    proxyPort = await startProxy({
+      OAS_CODEX_AUTH_PATH: codexAuthPath,
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/v1/responses',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(refreshBodies[0]).toContain('refresh_token=stale-refresh-token');
+    expect(refreshBodies[1]).toContain('refresh_token=fresh-refresh-token');
+    expect(lastUpstreamHeaders['authorization']).toBe(
+      `Bearer ${refreshedAccessToken}`,
+    );
   });
 
   it('codex mode deduplicates concurrent refresh calls', async () => {

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -131,12 +131,14 @@ export function startCredentialProxy(
             resolvedApiKey = providerConfig.apiKey;
           }
 
-          const headers: Record<string, string | number | string[] | undefined> =
-            {
-              ...(req.headers as Record<string, string>),
-              host: upstreamUrl.host,
-              'content-length': body.length,
-            };
+          const headers: Record<
+            string,
+            string | number | string[] | undefined
+          > = {
+            ...(req.headers as Record<string, string>),
+            host: upstreamUrl.host,
+            'content-length': body.length,
+          };
 
           // プロキシによって転送してはならないホップバイホップ・ヘッダーを削除
           delete headers['connection'];

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -8,6 +8,7 @@ import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
 
 import { logger } from './logger.js';
+import { resolveCodexOAuthApiKey } from './codex-oauth.js';
 import { detectActiveProviderConfig } from './provider-config.js';
 
 function buildUpstreamPath(upstreamUrl: URL, requestUrl?: string): string {
@@ -36,7 +37,7 @@ function buildUpstreamPath(upstreamUrl: URL, requestUrl?: string): string {
 
 function injectAuthHeaders(
   headers: Record<string, string | number | string[] | undefined>,
-  provider: 'anthropic' | 'openai',
+  provider: 'anthropic' | 'openai' | 'codex',
   apiKey: string,
 ): void {
   if (provider === 'anthropic') {
@@ -45,14 +46,17 @@ function injectAuthHeaders(
     return;
   }
 
-  // OpenAI 互換 API は Authorization Bearer を使うのが標準だが、
-  // x-api-key を使う実装にも対応できるよう、存在時は両方を置き換える。
-  delete headers['authorization'];
-  headers['authorization'] = `Bearer ${apiKey}`;
+  if (provider === 'openai' || provider === 'codex') {
+    // Codex は OpenAI 互換エンドポイントなので Bearer 注入ルールを共有する。
+    // OpenAI 互換 API は Authorization Bearer を使うのが標準だが、
+    // x-api-key を使う実装にも対応できるよう、存在時は両方を置き換える。
+    delete headers['authorization'];
+    headers['authorization'] = `Bearer ${apiKey}`;
 
-  if (headers['x-api-key'] !== undefined) {
-    delete headers['x-api-key'];
-    headers['x-api-key'] = apiKey;
+    if (headers['x-api-key'] !== undefined) {
+      delete headers['x-api-key'];
+      headers['x-api-key'] = apiKey;
+    }
   }
 }
 
@@ -90,7 +94,8 @@ export function startCredentialProxy(
 
   if (
     providerConfig.provider !== 'anthropic' &&
-    providerConfig.provider !== 'openai'
+    providerConfig.provider !== 'openai' &&
+    providerConfig.provider !== 'codex'
   ) {
     throw new Error(
       `Credential proxy cannot route provider ${providerConfig.provider}.`,
@@ -107,88 +112,112 @@ export function startCredentialProxy(
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
-        const body = Buffer.concat(chunks);
-        if (!providerConfig.apiKey) {
-          logger.error(
-            { provider: providerConfig.provider },
-            'API key is missing for proxied provider',
-          );
-          res.writeHead(500);
-          res.end('Credential proxy misconfiguration');
-          return;
-        }
+        void (async () => {
+          const body = Buffer.concat(chunks);
 
-        const headers: Record<string, string | number | string[] | undefined> =
-          {
-            ...(req.headers as Record<string, string>),
-            host: upstreamUrl.host,
-            'content-length': body.length,
-          };
-
-        // プロキシによって転送してはならないホップバイホップ・ヘッダーを削除
-        delete headers['connection'];
-        delete headers['keep-alive'];
-        delete headers['transfer-encoding'];
-
-        injectAuthHeaders(headers, proxiedProvider, providerConfig.apiKey);
-
-        const upstream = makeRequest(
-          {
-            hostname: upstreamUrl.hostname,
-            port: upstreamUrl.port || (isHttps ? 443 : 80),
-            path: buildUpstreamPath(upstreamUrl, req.url),
-            method: req.method,
-            headers,
-          } as RequestOptions,
-          (upRes) => {
-            res.writeHead(upRes.statusCode!, upRes.headers);
-            upRes.pipe(res);
-            // ストリーミング中の接続断を適切に処理
-            upRes.on('error', (err) => {
-              logger.error(
-                { err, url: req.url },
-                'Credential proxy upstream response error',
-              );
-              if (!res.destroyed) res.destroy();
+          let resolvedApiKey: string;
+          if (proxiedProvider === 'codex') {
+            const resolved = await resolveCodexOAuthApiKey({
+              authPath: providerConfig.codexAuthPath,
+              oauthJson: providerConfig.codexOAuthJson,
             });
-          },
-        );
-
-        // TCPキープアライブを有効化して長いストリーミング中の ETIMEDOUT を防ぐ。
-        // 30_000 は最初の keepalive probe までの初期遅延（ms）で、以降の間隔は OS 依存。
-        const applyKeepAlive = () => {
-          if (!upstream.socket) return false;
-          upstream.socket.setKeepAlive(true, 30_000);
-          return true;
-        };
-        if (!applyKeepAlive()) {
-          upstream.once('socket', () => {
-            applyKeepAlive();
-          });
-        }
-
-        // 下流（コンテナ側）が切断したら upstream を即時中止する。
-        res.on('close', () => {
-          if (!res.writableEnded && !upstream.destroyed) {
-            upstream.destroy();
+            resolvedApiKey = resolved.apiKey;
+          } else {
+            if (!providerConfig.apiKey) {
+              throw new Error(
+                `API key is missing for proxied provider ${providerConfig.provider}.`,
+              );
+            }
+            resolvedApiKey = providerConfig.apiKey;
           }
-        });
 
-        upstream.on('error', (err) => {
+          const headers: Record<string, string | number | string[] | undefined> =
+            {
+              ...(req.headers as Record<string, string>),
+              host: upstreamUrl.host,
+              'content-length': body.length,
+            };
+
+          // プロキシによって転送してはならないホップバイホップ・ヘッダーを削除
+          delete headers['connection'];
+          delete headers['keep-alive'];
+          delete headers['transfer-encoding'];
+
+          injectAuthHeaders(headers, proxiedProvider, resolvedApiKey);
+
+          const upstream = makeRequest(
+            {
+              hostname: upstreamUrl.hostname,
+              port: upstreamUrl.port || (isHttps ? 443 : 80),
+              path: buildUpstreamPath(upstreamUrl, req.url),
+              method: req.method,
+              headers,
+            } as RequestOptions,
+            (upRes) => {
+              res.writeHead(upRes.statusCode!, upRes.headers);
+              upRes.pipe(res);
+              // ストリーミング中の接続断を適切に処理
+              upRes.on('error', (err) => {
+                logger.error(
+                  { err, url: req.url },
+                  'Credential proxy upstream response error',
+                );
+                if (!res.destroyed) res.destroy();
+              });
+            },
+          );
+
+          // TCPキープアライブを有効化して長いストリーミング中の ETIMEDOUT を防ぐ。
+          // 30_000 は最初の keepalive probe までの初期遅延（ms）で、以降の間隔は OS 依存。
+          const applyKeepAlive = () => {
+            if (!upstream.socket) return false;
+            upstream.socket.setKeepAlive(true, 30_000);
+            return true;
+          };
+          if (!applyKeepAlive()) {
+            upstream.once('socket', () => {
+              applyKeepAlive();
+            });
+          }
+
+          // 下流（コンテナ側）が切断したら upstream を即時中止する。
+          res.on('close', () => {
+            if (!res.writableEnded && !upstream.destroyed) {
+              upstream.destroy();
+            }
+          });
+
+          upstream.on('error', (err) => {
+            logger.error(
+              { err, url: req.url },
+              'Credential proxy upstream error',
+            );
+            if (!res.headersSent) {
+              res.writeHead(502);
+              res.end('Bad Gateway');
+            } else if (!res.destroyed) {
+              res.destroy();
+            }
+          });
+
+          upstream.write(body);
+          upstream.end();
+        })().catch((err) => {
           logger.error(
-            { err, url: req.url },
-            'Credential proxy upstream error',
+            { err, provider: providerConfig.provider, url: req.url },
+            'Credential proxy failed to resolve provider credentials',
           );
           if (!res.headersSent) {
-            res.writeHead(502);
-            res.end('Bad Gateway');
+            res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+            res.end(
+              err instanceof Error
+                ? err.message
+                : 'Credential proxy misconfiguration',
+            );
           } else if (!res.destroyed) {
             res.destroy();
           }
         });
-
-        upstream.write(body);
-        upstream.end();
       });
     });
 

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -211,11 +211,7 @@ export function startCredentialProxy(
           );
           if (!res.headersSent) {
             res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
-            res.end(
-              err instanceof Error
-                ? err.message
-                : 'Credential proxy misconfiguration',
-            );
+            res.end('Credential proxy credential resolution failed.');
           } else if (!res.destroyed) {
             res.destroy();
           }

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnv: Record<string, string> = {};
 
@@ -26,7 +26,7 @@ describe('provider-config', () => {
     process.env.CODEX_HOME = '/tmp/nanoclaw-provider-config-tests';
   });
 
-  afterAll(() => {
+  afterEach(() => {
     if (originalCodexHome === undefined) {
       delete process.env.CODEX_HOME;
     } else {

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnv: Record<string, string> = {};
@@ -9,6 +11,7 @@ vi.mock('./env.js', () => ({
 import {
   buildContainerProviderEnv,
   detectActiveProviderConfig,
+  resolveCodexAuthPath,
 } from './provider-config.js';
 import { makeCodexCliAuthJson } from './codex-oauth-test-helpers.js';
 
@@ -116,6 +119,26 @@ describe('provider-config', () => {
   it('throws when no supported provider config is present', () => {
     expect(() => detectActiveProviderConfig()).toThrow(
       'No supported provider credentials found',
+    );
+  });
+
+  it('expands codex auth path when env path is ~/...', () => {
+    expect(resolveCodexAuthPath('~/.codex/auth.json')).toBe(
+      `${os.homedir()}/.codex/auth.json`,
+    );
+  });
+
+  it('expands codex auth path when env path is exactly ~', () => {
+    expect(resolveCodexAuthPath('~')).toBe(os.homedir());
+  });
+
+  it('does not expand codex auth path for absolute or relative paths', () => {
+    expect(resolveCodexAuthPath('/tmp/auth.json')).toBe('/tmp/auth.json');
+    expect(resolveCodexAuthPath('relative/auth.json')).toBe(
+      'relative/auth.json',
+    );
+    expect(resolveCodexAuthPath('~someone/auth.json')).toBe(
+      '~someone/auth.json',
     );
   });
 

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnv: Record<string, string> = {};
 
@@ -10,6 +10,9 @@ import {
   buildContainerProviderEnv,
   detectActiveProviderConfig,
 } from './provider-config.js';
+import { makeCodexCliAuthJson } from './codex-oauth-test-helpers.js';
+
+const originalCodexHome = process.env.CODEX_HOME;
 
 function resetMockEnv(): void {
   for (const key of Object.keys(mockEnv)) {
@@ -20,6 +23,15 @@ function resetMockEnv(): void {
 describe('provider-config', () => {
   beforeEach(() => {
     resetMockEnv();
+    process.env.CODEX_HOME = '/tmp/nanoclaw-provider-config-tests';
+  });
+
+  afterAll(() => {
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
+    }
   });
 
   it('detects anthropic first when multiple provider keys exist', () => {
@@ -27,7 +39,9 @@ describe('provider-config', () => {
       ANTHROPIC_API_KEY: 'sk-ant',
       OPENAI_API_KEY: 'sk-openai',
       GEMINI_API_KEY: 'gem-key',
-      OAS_CODEX_OAUTH_JSON: '{"access":"a","refresh":"r","expires":1}',
+      OAS_CODEX_OAUTH_JSON: makeCodexCliAuthJson({
+        expiresAtMs: Date.now() + 60_000,
+      }),
     });
 
     const config = detectActiveProviderConfig();
@@ -65,16 +79,17 @@ describe('provider-config', () => {
     expect(config.apiKey).toBe('gem-key');
   });
 
-  it('detects codex from oauth json when no API key providers exist and opt-in is enabled', () => {
+  it('detects codex from oauth json when no API key providers exist', () => {
     Object.assign(mockEnv, {
-      OAS_CODEX_OAUTH_JSON: '{"access":"a","refresh":"r","expires":1}',
-      ALLOW_DIRECT_SECRET_INJECTION: 'true',
+      OAS_CODEX_OAUTH_JSON: makeCodexCliAuthJson({
+        expiresAtMs: Date.now() + 60_000,
+      }),
     });
 
     const config = detectActiveProviderConfig();
     expect(config.provider).toBe('codex');
-    expect(config.usesCredentialProxy).toBe(false);
-    expect(config.allowDirectSecretInjection).toBe(true);
+    expect(config.usesCredentialProxy).toBe(true);
+    expect(config.allowDirectSecretInjection).toBe(false);
     expect(config.codexOAuthJson).toContain('access');
   });
 
@@ -88,13 +103,13 @@ describe('provider-config', () => {
     );
   });
 
-  it('throws when codex oauth is set without direct injection opt-in', () => {
+  it('throws when codex auth path is set but file does not exist', () => {
     Object.assign(mockEnv, {
-      OAS_CODEX_OAUTH_JSON: '{"access":"a","refresh":"r","expires":1}',
+      OAS_CODEX_AUTH_PATH: '/tmp/nanoclaw-missing-codex-auth.json',
     });
 
     expect(() => detectActiveProviderConfig()).toThrow(
-      'ALLOW_DIRECT_SECRET_INJECTION=true is not set',
+      'Codex auth file was not found',
     );
   });
 
@@ -157,20 +172,20 @@ describe('provider-config', () => {
     expect(env).toEqual({ GEMINI_API_KEY: 'gem-key' });
   });
 
-  it('builds codex oauth injection env', () => {
+  it('builds codex proxy env', () => {
     const env = buildContainerProviderEnv(
       {
         provider: 'codex',
-        usesCredentialProxy: false,
-        allowDirectSecretInjection: true,
-        codexOAuthJson: '{"access":"a","refresh":"r","expires":1}',
+        usesCredentialProxy: true,
+        allowDirectSecretInjection: false,
       },
       'host.docker.internal',
       3001,
     );
 
     expect(env).toEqual({
-      OAS_CODEX_OAUTH_JSON: '{"access":"a","refresh":"r","expires":1}',
+      CODEX_BASE_URL: 'http://host.docker.internal:3001',
+      CODEX_API_KEY: 'placeholder',
     });
   });
 

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -60,9 +60,13 @@ function isDirectSecretInjectionEnabled(value: string | undefined): boolean {
 
 export function resolveCodexAuthPath(envPath: string | undefined): string {
   if (envPath) {
-    return envPath.startsWith('~')
-      ? path.join(os.homedir(), envPath.slice(1))
-      : envPath;
+    if (envPath === '~') {
+      return os.homedir();
+    }
+    if (envPath.startsWith('~/')) {
+      return path.join(os.homedir(), envPath.slice(2));
+    }
+    return envPath;
   }
 
   const codexHome = process.env.CODEX_HOME

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { readEnvFile } from './env.js';
 import {
+  CodexAuthFileNotFoundError,
   validateCodexAuthFile,
   validateCodexOAuthJson,
 } from './codex-oauth.js';
@@ -141,10 +142,9 @@ export function detectActiveProviderConfig(): ActiveProviderConfig {
         try {
           validateCodexAuthFile(codexAuthPath);
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
           if (
             !hasExplicitCodexAuthPath &&
-            message.includes('Codex auth file was not found')
+            err instanceof CodexAuthFileNotFoundError
           ) {
             continue;
           }

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -1,8 +1,11 @@
-import fs from 'fs';
-import path from 'path';
 import os from 'os';
+import path from 'path';
 
 import { readEnvFile } from './env.js';
+import {
+  validateCodexAuthFile,
+  validateCodexOAuthJson,
+} from './codex-oauth.js';
 
 export type LlmProvider = 'anthropic' | 'openai' | 'gemini' | 'codex';
 
@@ -13,6 +16,7 @@ export interface ActiveProviderConfig {
   apiKey?: string;
   upstreamBaseURL?: string;
   codexOAuthJson?: string;
+  codexAuthPath?: string;
 }
 
 const PROVIDER_PRIORITY: LlmProvider[] = [
@@ -53,30 +57,21 @@ function isDirectSecretInjectionEnabled(value: string | undefined): boolean {
   return value === 'true';
 }
 
-function resolveCodexAuthPath(envPath: string | undefined): string {
+export function resolveCodexAuthPath(envPath: string | undefined): string {
   if (envPath) {
     return envPath.startsWith('~')
       ? path.join(os.homedir(), envPath.slice(1))
       : envPath;
   }
+
   const codexHome = process.env.CODEX_HOME
     ? path.resolve(process.env.CODEX_HOME)
     : path.join(os.homedir(), '.codex');
   return path.join(codexHome, 'auth.json');
 }
 
-function readCodexAuthFile(authPath: string): string | undefined {
-  try {
-    const content = fs.readFileSync(authPath, 'utf-8');
-    JSON.parse(content);
-    return content;
-  } catch {
-    return undefined;
-  }
-}
-
 function requireDirectSecretInjectionOptIn(
-  provider: 'gemini' | 'codex',
+  provider: 'gemini',
   enabled: boolean,
 ): void {
   if (enabled) return;
@@ -137,17 +132,35 @@ export function detectActiveProviderConfig(): ActiveProviderConfig {
 
     if (provider === 'codex') {
       const codexAuthPath = resolveCodexAuthPath(env.OAS_CODEX_AUTH_PATH);
-      const codexOAuthJson =
-        env.OAS_CODEX_OAUTH_JSON || readCodexAuthFile(codexAuthPath);
+      const codexOAuthJson = env.OAS_CODEX_OAUTH_JSON;
+      const hasExplicitCodexAuthPath = Boolean(env.OAS_CODEX_AUTH_PATH);
+
       if (codexOAuthJson) {
-        requireDirectSecretInjectionOptIn(provider, allowDirectSecretInjection);
-        return {
-          provider,
-          usesCredentialProxy: false,
-          allowDirectSecretInjection,
-          codexOAuthJson,
-        };
+        validateCodexOAuthJson(codexOAuthJson);
+      } else {
+        try {
+          validateCodexAuthFile(codexAuthPath);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (
+            !hasExplicitCodexAuthPath &&
+            message.includes('Codex auth file was not found')
+          ) {
+            continue;
+          }
+          throw err;
+        }
       }
+
+      return {
+        provider,
+        usesCredentialProxy: true,
+        allowDirectSecretInjection: false,
+        upstreamBaseURL:
+          env.OPENAI_BASE_URL || DEFAULT_UPSTREAM_BASE_URL.openai,
+        codexAuthPath,
+        ...(codexOAuthJson ? { codexOAuthJson } : {}),
+      };
     }
   }
 
@@ -164,10 +177,7 @@ export function detectActiveProviderConfig(): ActiveProviderConfig {
 function assertDirectSecretInjectionAllowed(
   providerConfig: ActiveProviderConfig,
 ): void {
-  if (
-    providerConfig.provider !== 'gemini' &&
-    providerConfig.provider !== 'codex'
-  ) {
+  if (providerConfig.provider !== 'gemini') {
     return;
   }
 
@@ -215,12 +225,14 @@ export function buildContainerProviderEnv(
     };
   }
 
-  assertDirectSecretInjectionAllowed(providerConfig);
+  if (!providerConfig.usesCredentialProxy) {
+    throw new Error(
+      '[provider-config] codex provider must use credential proxy.',
+    );
+  }
+
   return {
-    OAS_CODEX_OAUTH_JSON: requiredValue(
-      providerConfig.codexOAuthJson,
-      'OAS_CODEX_OAUTH_JSON',
-      providerConfig.provider,
-    ),
+    CODEX_BASE_URL: proxyBaseUrl,
+    CODEX_API_KEY: 'placeholder',
   };
 }


### PR DESCRIPTION
## Summary

OpenAI Codex CLIのOAuth認証をサポートする機能を追加します。

## Changes

### Core Features
- **Codex OAuth認証モジュール** (`src/codex-oauth.ts`)
  - OAuthトークンの解決と自動更新
  - JWTトークンのパース（expiry, account_id抽出）
  - ファイルベースと環境変数ベースの認証設定対応

- **認証情報プロキシ統合** (`src/credential-proxy.ts`)
  - Codexを新しいLLMプロバイダーとして追加
  - OAuthトークンの注入と更新フロー
  - 長時間ストリーミング接続用のTCP keepalive

- **プロバイダー設定** (`src/provider-config.ts`)
  - プロバイダー優先順位に'codex'を追加
  - `OAS_CODEX_AUTH_PATH`/`OAS_CODEX_OAUTH_JSON`の検証
  - `CODEX_BASE_URL`と`CODEX_API_KEY`のコンテナ環境変数マッピング

- **エージェントランナー** (`container/agent-runner/src/index.ts`)
  - `CodexOAuthOptions`をopen-agent-sdkからインポート
  - JWTデコードとOAuth credential正規化の実装

### Documentation
- `SECURITY.md`を更新してCodexプロキシモードを反映
- `.env.example`のコメントを修正（Codexは直接注入不要）

### Tests
- Codex認証フローの包括的なテスト追加
- 並行リフレッシュ呼び出しの重複排除テスト
- 期限切れトークンの自動更新テスト