### PR TITLE
feat: allow specific bot IDs to bypass Discord bot filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ DISCORD_BOT_TOKEN=
 # botフィルターをバイパスするDiscord Bot IDのカンマ区切りリスト (省略可)
 # RSSボット (Feedcord等) のメッセージを thread_per_message チャンネルで処理する場合に設定
 # Bot IDはDiscordの開発者ポータル、またはDiscordのIDコピー機能で確認できる (17〜20桁の数字)
+# ※ 変更後はサービスの再起動が必要
 # DISCORD_ALLOWED_BOT_IDS=123456789012345678,987654321098765432
 
 # --- LLM プロバイダー認証 (いずれか1つを設定) ---

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,11 @@ TZ=
 # Discord チャンネルの使用に必須
 DISCORD_BOT_TOKEN=
 
+# botフィルターをバイパスするDiscord Bot IDのカンマ区切りリスト (省略可)
+# RSSボット (Feedcord等) のメッセージを thread_per_message チャンネルで処理する場合に設定
+# Bot IDはDiscordの開発者ポータル、またはDiscordのIDコピー機能で確認できる (17〜20桁の数字)
+# DISCORD_ALLOWED_BOT_IDS=123456789012345678,987654321098765432
+
 # --- LLM プロバイダー認証 (いずれか1つを設定) ---
 
 # Anthropic API キー (プロキシ経由、推奨)

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -905,6 +905,88 @@ describe('DiscordChannel', () => {
     });
   });
 
+  // --- Allowed bot filtering ---
+
+  describe('allowed bot filtering', () => {
+    const ALLOWED_BOT_ID = '111222333444555666';
+
+    it('delivers message from allowed bot in thread_per_message channel', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'dc:1234567890123456': {
+            name: 'Test Server #general',
+            folder: 'test-server',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+            channel_mode: 'thread_per_message' as const,
+          },
+        })),
+      });
+      const channel = new DiscordChannel('test-token', new Set([ALLOWED_BOT_ID]), opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        isBot: true,
+        authorId: ALLOWED_BOT_ID,
+        content: 'Bot report ready',
+        guildName: 'Test Server',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          sender: ALLOWED_BOT_ID,
+          content: 'Bot report ready',
+        }),
+      );
+    });
+
+    it('drops allowed bot message in non-thread_per_message channel', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'dc:1234567890123456': {
+            name: 'Test Server #general',
+            folder: 'test-server',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+            // channel_mode 未設定 = thread_per_message 以外
+          },
+        })),
+      });
+      const channel = new DiscordChannel('test-token', new Set([ALLOWED_BOT_ID]), opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        isBot: true,
+        authorId: ALLOWED_BOT_ID,
+        content: 'Bot report ready',
+        guildName: 'Test Server',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-allowed bot even if allowedBotIds is set', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', new Set([ALLOWED_BOT_ID]), opts);
+      await channel.connect();
+
+      const msg = createMessage({
+        isBot: true,
+        authorId: '999111222333444555', // allowedBotIds に含まれない別 Bot
+        content: 'I am another bot',
+        guildName: 'Test Server',
+      });
+      await triggerMessage(msg);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+  });
+
   // --- Thread detection ---
 
   describe('thread detection', () => {

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -835,22 +835,38 @@ describe('DiscordChannel', () => {
 
   describe('ownsJid', () => {
     it('owns dc: JIDs', () => {
-      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set(),
+        createTestOpts(),
+      );
       expect(channel.ownsJid('dc:1234567890123456')).toBe(true);
     });
 
     it('does not own WhatsApp group JIDs', () => {
-      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set(),
+        createTestOpts(),
+      );
       expect(channel.ownsJid('12345@g.us')).toBe(false);
     });
 
     it('does not own Telegram JIDs', () => {
-      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set(),
+        createTestOpts(),
+      );
       expect(channel.ownsJid('tg:123456789')).toBe(false);
     });
 
     it('does not own unknown JID formats', () => {
-      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set(),
+        createTestOpts(),
+      );
       expect(channel.ownsJid('random-string')).toBe(false);
     });
   });
@@ -900,7 +916,11 @@ describe('DiscordChannel', () => {
 
   describe('channel properties', () => {
     it('has name "discord"', () => {
-      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set(),
+        createTestOpts(),
+      );
       expect(channel.name).toBe('discord');
     });
   });
@@ -922,7 +942,11 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', new Set([ALLOWED_BOT_ID]), opts);
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set([ALLOWED_BOT_ID]),
+        opts,
+      );
       await channel.connect();
 
       const msg = createMessage({
@@ -954,7 +978,11 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', new Set([ALLOWED_BOT_ID]), opts);
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set([ALLOWED_BOT_ID]),
+        opts,
+      );
       await channel.connect();
 
       const msg = createMessage({
@@ -971,7 +999,11 @@ describe('DiscordChannel', () => {
 
     it('ignores non-allowed bot even if allowedBotIds is set', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', new Set([ALLOWED_BOT_ID]), opts);
+      const channel = new DiscordChannel(
+        'test-token',
+        new Set([ALLOWED_BOT_ID]),
+        opts,
+      );
       await channel.connect();
 
       const msg = createMessage({

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -232,7 +232,7 @@ describe('DiscordChannel', () => {
   describe('connection lifecycle', () => {
     it('resolves connect() when client is ready', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
 
       await channel.connect();
 
@@ -241,7 +241,7 @@ describe('DiscordChannel', () => {
 
     it('registers message handlers on connect', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
 
       await channel.connect();
 
@@ -252,7 +252,7 @@ describe('DiscordChannel', () => {
 
     it('disconnects cleanly', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
 
       await channel.connect();
       expect(channel.isConnected()).toBe(true);
@@ -263,7 +263,7 @@ describe('DiscordChannel', () => {
 
     it('isConnected() returns false before connect', () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
 
       expect(channel.isConnected()).toBe(false);
     });
@@ -274,7 +274,7 @@ describe('DiscordChannel', () => {
   describe('text message handling', () => {
     it('delivers message for registered channel', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -309,7 +309,7 @@ describe('DiscordChannel', () => {
 
     it('only emits metadata for unregistered channels', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -331,7 +331,7 @@ describe('DiscordChannel', () => {
 
     it('ignores bot messages', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({ isBot: true, content: 'I am a bot' });
@@ -343,7 +343,7 @@ describe('DiscordChannel', () => {
 
     it('uses member displayName when available (server nickname)', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -362,7 +362,7 @@ describe('DiscordChannel', () => {
 
     it('falls back to author displayName when no member', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -390,7 +390,7 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -416,7 +416,7 @@ describe('DiscordChannel', () => {
 
     it('uses guild name + channel name for server messages', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -441,7 +441,7 @@ describe('DiscordChannel', () => {
   describe('@mention translation', () => {
     it('translates <@botId> mention to trigger format', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -461,7 +461,7 @@ describe('DiscordChannel', () => {
 
     it('does not translate if message already matches trigger', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -483,7 +483,7 @@ describe('DiscordChannel', () => {
 
     it('does not translate when bot is not mentioned', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -502,7 +502,7 @@ describe('DiscordChannel', () => {
 
     it('handles <@!botId> (nickname mention format)', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -526,7 +526,7 @@ describe('DiscordChannel', () => {
   describe('attachments', () => {
     it('stores image attachment with placeholder', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const attachments = new Map([
@@ -549,7 +549,7 @@ describe('DiscordChannel', () => {
 
     it('stores video attachment with placeholder', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const attachments = new Map([
@@ -572,7 +572,7 @@ describe('DiscordChannel', () => {
 
     it('stores file attachment with placeholder', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const attachments = new Map([
@@ -595,7 +595,7 @@ describe('DiscordChannel', () => {
 
     it('includes text content with attachments', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const attachments = new Map([
@@ -618,7 +618,7 @@ describe('DiscordChannel', () => {
 
     it('handles multiple attachments', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const attachments = new Map([
@@ -646,7 +646,7 @@ describe('DiscordChannel', () => {
   describe('reply context', () => {
     it('includes reply author in content', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -670,7 +670,7 @@ describe('DiscordChannel', () => {
   describe('sendMessage', () => {
     it('sends message via channel', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       await channel.sendMessage('dc:1234567890123456', 'Hello');
@@ -684,7 +684,7 @@ describe('DiscordChannel', () => {
 
     it('strips dc: prefix from JID', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       await channel.sendMessage('dc:9876543210', 'Test');
@@ -694,7 +694,7 @@ describe('DiscordChannel', () => {
 
     it('handles send failure gracefully', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       currentClient().channels.fetch.mockRejectedValueOnce(
@@ -709,7 +709,7 @@ describe('DiscordChannel', () => {
 
     it('does nothing when client is not initialized', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
 
       // Don't connect — client is null
       await channel.sendMessage('dc:1234567890123456', 'No client');
@@ -719,7 +719,7 @@ describe('DiscordChannel', () => {
 
     it('splits messages exceeding 2000 characters', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const mockChannel = {
@@ -742,7 +742,7 @@ describe('DiscordChannel', () => {
   describe('createThread', () => {
     it('creates message-linked thread when messageId is provided', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const mockThreadsCreate = vi
@@ -773,7 +773,7 @@ describe('DiscordChannel', () => {
 
     it('falls back to standalone thread when linked creation fails', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const mockThreadsCreate = vi
@@ -806,7 +806,7 @@ describe('DiscordChannel', () => {
 
     it('creates standalone thread when messageId is omitted', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const mockThreadsCreate = vi
@@ -835,22 +835,22 @@ describe('DiscordChannel', () => {
 
   describe('ownsJid', () => {
     it('owns dc: JIDs', () => {
-      const channel = new DiscordChannel('test-token', createTestOpts());
+      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
       expect(channel.ownsJid('dc:1234567890123456')).toBe(true);
     });
 
     it('does not own WhatsApp group JIDs', () => {
-      const channel = new DiscordChannel('test-token', createTestOpts());
+      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
       expect(channel.ownsJid('12345@g.us')).toBe(false);
     });
 
     it('does not own Telegram JIDs', () => {
-      const channel = new DiscordChannel('test-token', createTestOpts());
+      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
       expect(channel.ownsJid('tg:123456789')).toBe(false);
     });
 
     it('does not own unknown JID formats', () => {
-      const channel = new DiscordChannel('test-token', createTestOpts());
+      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
       expect(channel.ownsJid('random-string')).toBe(false);
     });
   });
@@ -860,7 +860,7 @@ describe('DiscordChannel', () => {
   describe('setTyping', () => {
     it('sends typing indicator when isTyping is true', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const mockChannel = {
@@ -876,7 +876,7 @@ describe('DiscordChannel', () => {
 
     it('does nothing when isTyping is false', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       await channel.setTyping('dc:1234567890123456', false);
@@ -887,7 +887,7 @@ describe('DiscordChannel', () => {
 
     it('does nothing when client is not initialized', async () => {
       const opts = createTestOpts();
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
 
       // Don't connect
       await channel.setTyping('dc:1234567890123456', true);
@@ -900,7 +900,7 @@ describe('DiscordChannel', () => {
 
   describe('channel properties', () => {
     it('has name "discord"', () => {
-      const channel = new DiscordChannel('test-token', createTestOpts());
+      const channel = new DiscordChannel('test-token', new Set(), createTestOpts());
       expect(channel.name).toBe('discord');
     });
   });
@@ -921,7 +921,7 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -958,7 +958,7 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -995,7 +995,7 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({
@@ -1033,7 +1033,7 @@ describe('DiscordChannel', () => {
           },
         })),
       });
-      const channel = new DiscordChannel('test-token', opts);
+      const channel = new DiscordChannel('test-token', new Set(), opts);
       await channel.connect();
 
       const msg = createMessage({

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -66,9 +66,15 @@ export class DiscordChannel implements Channel {
       ],
     });
 
+    const { DISCORD_ALLOWED_BOT_IDS: allowedBotIdsRaw } = readEnvFile([
+      'DISCORD_ALLOWED_BOT_IDS',
+    ]);
+    const allowedBotIds = new Set(
+      allowedBotIdsRaw ? allowedBotIdsRaw.split(',').map((s) => s.trim()) : [],
+    );
+
     this.client.on(Events.MessageCreate, async (message: Message) => {
-      // Ignore bot messages (including own)
-      if (message.author.bot) return;
+      if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -91,11 +91,19 @@ export class DiscordChannel implements Channel {
     );
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
-      if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
+      const isAllowedBot =
+        message.author.bot && allowedBotIds.has(message.author.id);
+      if (message.author.bot && !isAllowedBot) return;
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;
       const chatJid = `dc:${channelId}`;
+
+      // 許可Botは thread_per_message チャンネルのみで処理する
+      if (isAllowedBot) {
+        const group = this.opts.registeredGroups()[chatJid];
+        if (group?.channel_mode !== 'thread_per_message') return;
+      }
       let content = message.content;
       const timestamp = message.createdAt.toISOString();
       const senderName =

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -52,7 +52,11 @@ export class DiscordChannel implements Channel {
   private botToken: string;
   private allowedBotIds: Set<string>;
 
-  constructor(botToken: string, allowedBotIds: Set<string>, opts: DiscordChannelOpts) {
+  constructor(
+    botToken: string,
+    allowedBotIds: Set<string>,
+    opts: DiscordChannelOpts,
+  ) {
     this.botToken = botToken;
     this.allowedBotIds = allowedBotIds;
     this.opts = opts;
@@ -69,7 +73,8 @@ export class DiscordChannel implements Channel {
     });
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
-      if (message.author.bot && !this.allowedBotIds.has(message.author.id)) return;
+      if (message.author.bot && !this.allowedBotIds.has(message.author.id))
+        return;
       const isPermittedBot = message.author.bot; // 早期returnを通過した bot は許可済み
 
       const isThread = message.channel.isThread();
@@ -395,7 +400,10 @@ registerChannel('discord', (opts: ChannelOpts) => {
           .map((s) => s.trim())
           .filter((id) => {
             if (!discordIdPattern.test(id)) {
-              logger.warn({ id }, 'DISCORD_ALLOWED_BOT_IDS: invalid ID skipped');
+              logger.warn(
+                { id },
+                'DISCORD_ALLOWED_BOT_IDS: invalid ID skipped',
+              );
               return false;
             }
             return true;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -71,8 +71,23 @@ export class DiscordChannel implements Channel {
     ]);
     const allowedBotIdsRaw =
       process.env.DISCORD_ALLOWED_BOT_IDS ?? allowedBotIdsFile;
+    const discordIdPattern = /^\d{17,20}$/;
     const allowedBotIds = new Set(
-      allowedBotIdsRaw ? allowedBotIdsRaw.split(',').map((s) => s.trim()) : [],
+      allowedBotIdsRaw
+        ? allowedBotIdsRaw
+            .split(',')
+            .map((s) => s.trim())
+            .filter((id) => {
+              if (!discordIdPattern.test(id)) {
+                logger.warn(
+                  { id },
+                  'DISCORD_ALLOWED_BOT_IDS: invalid ID skipped',
+                );
+                return false;
+              }
+              return true;
+            })
+        : [],
     );
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
@@ -240,13 +255,23 @@ export class DiscordChannel implements Channel {
     return new Promise<void>((resolve) => {
       this.client!.once(Events.ClientReady, (readyClient) => {
         logger.info(
-          { username: readyClient.user.tag, id: readyClient.user.id },
+          {
+            username: readyClient.user.tag,
+            id: readyClient.user.id,
+            allowedBotIds: [...allowedBotIds],
+          },
           'Discord bot connected',
         );
         console.log(`\n  Discord bot: ${readyClient.user.tag}`);
         console.log(
-          `  Use /chatid command or check channel IDs in Discord settings\n`,
+          `  Use /chatid command or check channel IDs in Discord settings`,
         );
+        if (allowedBotIds.size > 0) {
+          console.log(
+            `  Allowed bot IDs (bypass filter): ${[...allowedBotIds].join(', ')}`,
+          );
+        }
+        console.log();
         resolve();
       });
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -94,7 +94,6 @@ export class DiscordChannel implements Channel {
       if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
       const isAllowedBot = message.author.bot;
 
-
       const isThread = message.channel.isThread();
       const channelId = message.channelId;
       const chatJid = `dc:${channelId}`;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -92,16 +92,22 @@ export class DiscordChannel implements Channel {
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
       if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
-      const isAllowedBot = message.author.bot;
+      const isPermittedBot = message.author.bot;
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;
       const chatJid = `dc:${channelId}`;
 
       // 許可Botは thread_per_message チャンネルのみで処理する
-      if (isAllowedBot) {
+      if (isPermittedBot) {
         const group = this.opts.registeredGroups()[chatJid];
-        if (group?.channel_mode !== 'thread_per_message') return;
+        if (group?.channel_mode !== 'thread_per_message') {
+          logger.debug(
+            { botId: message.author.id, chatJid },
+            'allowed bot message dropped: not thread_per_message channel',
+          );
+          return;
+        }
       }
       let content = message.content;
       const timestamp = message.createdAt.toISOString();

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -66,9 +66,11 @@ export class DiscordChannel implements Channel {
       ],
     });
 
-    const { DISCORD_ALLOWED_BOT_IDS: allowedBotIdsRaw } = readEnvFile([
+    const { DISCORD_ALLOWED_BOT_IDS: allowedBotIdsFile } = readEnvFile([
       'DISCORD_ALLOWED_BOT_IDS',
     ]);
+    const allowedBotIdsRaw =
+      process.env.DISCORD_ALLOWED_BOT_IDS ?? allowedBotIdsFile;
     const allowedBotIds = new Set(
       allowedBotIdsRaw ? allowedBotIdsRaw.split(',').map((s) => s.trim()) : [],
     );

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -70,7 +70,7 @@ export class DiscordChannel implements Channel {
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
       if (message.author.bot && !this.allowedBotIds.has(message.author.id)) return;
-      const isPermittedBot = message.author.bot && this.allowedBotIds.has(message.author.id);
+      const isPermittedBot = message.author.bot; // 早期returnを通過した bot は許可済み
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -68,11 +68,9 @@ export class DiscordChannel implements Channel {
       ],
     });
 
-    const allowedBotIds = this.allowedBotIds;
-
     this.client.on(Events.MessageCreate, async (message: Message) => {
-      if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
-      const isPermittedBot = message.author.bot && allowedBotIds.has(message.author.id);
+      if (message.author.bot && !this.allowedBotIds.has(message.author.id)) return;
+      const isPermittedBot = message.author.bot && this.allowedBotIds.has(message.author.id);
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;
@@ -251,7 +249,7 @@ export class DiscordChannel implements Channel {
           {
             username: readyClient.user.tag,
             id: readyClient.user.id,
-            allowedBotIds: [...allowedBotIds],
+            allowedBotIds: [...this.allowedBotIds],
           },
           'Discord bot connected',
         );
@@ -259,9 +257,9 @@ export class DiscordChannel implements Channel {
         console.log(
           `  Use /chatid command or check channel IDs in Discord settings`,
         );
-        if (allowedBotIds.size > 0) {
+        if (this.allowedBotIds.size > 0) {
           console.log(
-            `  Allowed bot IDs (bypass filter): ${[...allowedBotIds].join(', ')}`,
+            `  Allowed bot IDs (bypass filter): ${[...this.allowedBotIds].join(', ')}`,
           );
         }
         console.log();

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -92,7 +92,7 @@ export class DiscordChannel implements Channel {
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
       if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
-      const isPermittedBot = message.author.bot;
+      const isPermittedBot = message.author.bot && allowedBotIds.has(message.author.id);
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -91,9 +91,9 @@ export class DiscordChannel implements Channel {
     );
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
-      const isAllowedBot =
-        message.author.bot && allowedBotIds.has(message.author.id);
-      if (message.author.bot && !isAllowedBot) return;
+      if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
+      const isAllowedBot = message.author.bot;
+
 
       const isThread = message.channel.isThread();
       const channelId = message.channelId;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -50,9 +50,11 @@ export class DiscordChannel implements Channel {
   private client: Client | null = null;
   private opts: DiscordChannelOpts;
   private botToken: string;
+  private allowedBotIds: Set<string>;
 
-  constructor(botToken: string, opts: DiscordChannelOpts) {
+  constructor(botToken: string, allowedBotIds: Set<string>, opts: DiscordChannelOpts) {
     this.botToken = botToken;
+    this.allowedBotIds = allowedBotIds;
     this.opts = opts;
   }
 
@@ -66,29 +68,7 @@ export class DiscordChannel implements Channel {
       ],
     });
 
-    const { DISCORD_ALLOWED_BOT_IDS: allowedBotIdsFile } = readEnvFile([
-      'DISCORD_ALLOWED_BOT_IDS',
-    ]);
-    const allowedBotIdsRaw =
-      process.env.DISCORD_ALLOWED_BOT_IDS ?? allowedBotIdsFile;
-    const discordIdPattern = /^\d{17,20}$/;
-    const allowedBotIds = new Set(
-      allowedBotIdsRaw
-        ? allowedBotIdsRaw
-            .split(',')
-            .map((s) => s.trim())
-            .filter((id) => {
-              if (!discordIdPattern.test(id)) {
-                logger.warn(
-                  { id },
-                  'DISCORD_ALLOWED_BOT_IDS: invalid ID skipped',
-                );
-                return false;
-              }
-              return true;
-            })
-        : [],
-    );
+    const allowedBotIds = this.allowedBotIds;
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
       if (message.author.bot && !allowedBotIds.has(message.author.id)) return;
@@ -400,12 +380,29 @@ export class DiscordChannel implements Channel {
 }
 
 registerChannel('discord', (opts: ChannelOpts) => {
-  const envVars = readEnvFile(['DISCORD_BOT_TOKEN']);
+  const envVars = readEnvFile(['DISCORD_BOT_TOKEN', 'DISCORD_ALLOWED_BOT_IDS']);
   const token =
     process.env.DISCORD_BOT_TOKEN || envVars.DISCORD_BOT_TOKEN || '';
   if (!token) {
     logger.warn('Discord: DISCORD_BOT_TOKEN not set');
     return null;
   }
-  return new DiscordChannel(token, opts);
+  const allowedBotIdsRaw =
+    process.env.DISCORD_ALLOWED_BOT_IDS ?? envVars.DISCORD_ALLOWED_BOT_IDS;
+  const discordIdPattern = /^\d{17,20}$/;
+  const allowedBotIds = new Set(
+    allowedBotIdsRaw
+      ? allowedBotIdsRaw
+          .split(',')
+          .map((s) => s.trim())
+          .filter((id) => {
+            if (!discordIdPattern.test(id)) {
+              logger.warn({ id }, 'DISCORD_ALLOWED_BOT_IDS: invalid ID skipped');
+              return false;
+            }
+            return true;
+          })
+      : [],
+  );
+  return new DiscordChannel(token, allowedBotIds, opts);
 });


### PR DESCRIPTION
## Summary

- `DISCORD_ALLOWED_BOT_IDS` 環境変数（カンマ区切りのDiscord Bot ID）を追加
- リストに含まれるBot IDはbotフィルターをバイパスし、`thread_per_message`チャンネルで処理される
- 未設定時は従来通り全botを弾く（後方互換）

## 使い方

`.env` にRSSボット（FeedcordなどのBot ID）を追加するだけ：

```
DISCORD_ALLOWED_BOT_IDS=123456789012345678
```

## Test plan

- [ ] `DISCORD_ALLOWED_BOT_IDS` 未設定でbotメッセージが従来通り無視されることを確認
- [ ] 許可IDを設定したbotのメッセージが `thread_per_message` チャンネルでスレッドを生成することを確認
- [ ] 不正なID形式（17桁未満など）を設定した場合に起動ログに警告が出ることを確認
- [ ] 起動時に許可Bot IDがコンソールに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)