### PR TITLE
docs: ソースコードの英語コメントを日本語に翻訳

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -159,7 +159,7 @@ function createMessage(overrides: {
 }) {
   const channelId = overrides.channelId ?? '1234567890123456';
   const authorId = overrides.authorId ?? '55512345';
-  const botId = '999888777';   // モッククライアントのユーザーIDと一致
+  const botId = '999888777'; // モッククライアントのユーザーIDと一致
   const isThreadChannel = overrides.isThread ?? false;
 
   const mentionsMap = new Map();

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
-// --- Mocks ---
+// --- モック ---
 
-// Mock registry (registerChannel runs at import time)
+// レジストリのモック（registerChannel はインポート時に実行される）
 vi.mock('./registry.js', () => ({ registerChannel: vi.fn() }));
 
-// Mock env reader (used by the factory, not needed in unit tests)
+// 環境変数リーダーのモック（ファクトリで使用されるが、ユニットテストでは不要）
 vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
 
-// Mock config
+// 設定のモック
 vi.mock('../config.js', () => ({
   ASSISTANT_NAME: 'Andy',
   TRIGGER_PATTERN: /^@Andy\b/i,
 }));
 
-// Mock logger
+// ロガーのモック
 vi.mock('../logger.js', () => ({
   logger: {
     debug: vi.fn(),
@@ -24,7 +24,7 @@ vi.mock('../logger.js', () => ({
   },
 }));
 
-// --- discord.js mock ---
+// --- discord.js のモック ---
 
 type Handler = (...args: any[]) => any;
 
@@ -76,7 +76,7 @@ vi.mock('discord.js', () => {
 
     async login(_token: string) {
       this._ready = true;
-      // Fire the ready event
+      // ready イベントを発火させる
       const readyHandlers = this.eventHandlers.get('ready') || [];
       for (const h of readyHandlers) {
         h({ user: this.user });
@@ -99,10 +99,10 @@ vi.mock('discord.js', () => {
     }
   }
 
-  // Mock TextChannel type
+  // TextChannel 型のモック
   class TextChannel {}
 
-  // Mock ThreadChannel type
+  // ThreadChannel 型のモック
   class ThreadChannel {}
 
   return {
@@ -117,7 +117,7 @@ vi.mock('discord.js', () => {
 
 import { DiscordChannel, DiscordChannelOpts } from './discord.js';
 
-// --- Test helpers ---
+// --- テスト用ヘルパー ---
 
 function createTestOpts(
   overrides?: Partial<DiscordChannelOpts>,
@@ -159,7 +159,7 @@ function createMessage(overrides: {
 }) {
   const channelId = overrides.channelId ?? '1234567890123456';
   const authorId = overrides.authorId ?? '55512345';
-  const botId = '999888777'; // matches mock client user id
+  const botId = '999888777';   // モッククライアントのユーザーIDと一致
   const isThreadChannel = overrides.isThread ?? false;
 
   const mentionsMap = new Map();
@@ -216,7 +216,7 @@ async function triggerMessage(message: any) {
   for (const h of handlers) await h(message);
 }
 
-// --- Tests ---
+// --- テスト ---
 
 describe('DiscordChannel', () => {
   beforeEach(() => {
@@ -227,7 +227,7 @@ describe('DiscordChannel', () => {
     vi.restoreAllMocks();
   });
 
-  // --- Connection lifecycle ---
+  // --- 接続ライフサイクル ---
 
   describe('connection lifecycle', () => {
     it('resolves connect() when client is ready', async () => {
@@ -269,7 +269,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- Text message handling ---
+  // --- テキストメッセージ処理 ---
 
   describe('text message handling', () => {
     it('delivers message for registered channel', async () => {
@@ -436,7 +436,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- @mention translation ---
+  // --- @メンション変換 ---
 
   describe('@mention translation', () => {
     it('translates <@botId> mention to trigger format', async () => {
@@ -471,8 +471,8 @@ describe('DiscordChannel', () => {
       });
       await triggerMessage(msg);
 
-      // Should NOT prepend @Andy — already starts with trigger
-      // But the <@botId> should still be stripped
+      // @Andy を先頭に付加しない — すでにトリガーで始まっている
+      // ただし <@botId> は除去される
       expect(opts.onMessage).toHaveBeenCalledWith(
         'dc:1234567890123456',
         expect.objectContaining({
@@ -521,7 +521,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- Attachments ---
+  // --- 添付ファイル ---
 
   describe('attachments', () => {
     it('stores image attachment with placeholder', async () => {
@@ -641,7 +641,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- Reply context ---
+  // --- リプライ文脈 ---
 
   describe('reply context', () => {
     it('includes reply author in content', async () => {
@@ -665,7 +665,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- sendMessage ---
+  // --- メッセージ送信 ---
 
   describe('sendMessage', () => {
     it('sends message via channel', async () => {
@@ -701,7 +701,7 @@ describe('DiscordChannel', () => {
         new Error('Channel not found'),
       );
 
-      // Should not throw
+      // 例外を投げないこと
       await expect(
         channel.sendMessage('dc:1234567890123456', 'Will fail'),
       ).resolves.toBeUndefined();
@@ -711,10 +711,10 @@ describe('DiscordChannel', () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', new Set(), opts);
 
-      // Don't connect — client is null
+      // 接続しない — client が null
       await channel.sendMessage('dc:1234567890123456', 'No client');
 
-      // No error, no API call
+      // エラーも API 呼び出しもない
     });
 
     it('splits messages exceeding 2000 characters', async () => {
@@ -737,7 +737,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- createThread ---
+  // --- スレッド作成 ---
 
   describe('createThread', () => {
     it('creates message-linked thread when messageId is provided', async () => {
@@ -831,7 +831,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- ownsJid ---
+  // --- JID の所有判定 ---
 
   describe('ownsJid', () => {
     it('owns dc: JIDs', () => {
@@ -871,7 +871,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- setTyping ---
+  // --- タイピング表示 ---
 
   describe('setTyping', () => {
     it('sends typing indicator when isTyping is true', async () => {
@@ -897,7 +897,7 @@ describe('DiscordChannel', () => {
 
       await channel.setTyping('dc:1234567890123456', false);
 
-      // channels.fetch should NOT be called
+      // channels.fetch は呼ばれないこと
       expect(currentClient().channels.fetch).not.toHaveBeenCalled();
     });
 
@@ -905,14 +905,14 @@ describe('DiscordChannel', () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', new Set(), opts);
 
-      // Don't connect
+      // 接続しない
       await channel.setTyping('dc:1234567890123456', true);
 
-      // No error
+      // エラーは出ない
     });
   });
 
-  // --- Channel properties ---
+  // --- チャンネルプロパティ ---
 
   describe('channel properties', () => {
     it('has name "discord"', () => {
@@ -925,7 +925,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- Allowed bot filtering ---
+  // --- 許可Botフィルタリング ---
 
   describe('allowed bot filtering', () => {
     const ALLOWED_BOT_ID = '111222333444555666';
@@ -1019,7 +1019,7 @@ describe('DiscordChannel', () => {
     });
   });
 
-  // --- Thread detection ---
+  // --- スレッド検出 ---
 
   describe('thread detection', () => {
     it('sets is_thread=true and place_type=public_thread for thread messages', async () => {
@@ -1123,7 +1123,7 @@ describe('DiscordChannel', () => {
       });
       await triggerMessage(msg);
 
-      // Should deliver even though thread itself is not registered yet
+      // スレッド自体はまだ登録されていないが配信されること
       expect(opts.onMessage).toHaveBeenCalledWith(
         `dc:${threadId}`,
         expect.objectContaining({
@@ -1143,7 +1143,7 @@ describe('DiscordChannel', () => {
             folder: 'test-server',
             trigger: '@Andy',
             added_at: '2024-01-01T00:00:00.000Z',
-            // no thread_defaults
+            // thread_defaults なし
           },
         })),
       });

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -101,7 +101,7 @@ export class DiscordChannel implements Channel {
       const sender = message.author.id;
       const msgId = message.id;
 
-      // Determine chat name
+      // チャット名を決定する
       let chatName: string;
       if (message.guild) {
         if (isThread && message.channel.isThread()) {
@@ -116,16 +116,16 @@ export class DiscordChannel implements Channel {
         chatName = senderName;
       }
 
-      // Resolve parent JID for thread messages
+      // スレッドメッセージの親JIDを解決する
       let parentJid: string | undefined;
       if (isThread && message.channel.isThread() && message.channel.parentId) {
         parentJid = `dc:${message.channel.parentId}`;
       }
 
-      // Translate Discord @bot mentions into TRIGGER_PATTERN format.
-      // Discord mentions look like <@botUserId> — these won't match
-      // TRIGGER_PATTERN (e.g., ^@Andy\b), so we prepend the trigger
-      // when the bot is @mentioned.
+      // Discord の @bot メンションを TRIGGER_PATTERN 形式に変換する。
+      // Discord のメンションは <@botUserId> のような形式で、
+      // TRIGGER_PATTERN（例: ^@Andy\b）には一致しないため、
+      // bot が @mentioned されたときにトリガーを先頭に付加する。
       if (this.client?.user) {
         const botId = this.client.user.id;
         const isBotMentioned =
@@ -134,18 +134,18 @@ export class DiscordChannel implements Channel {
           content.includes(`<@!${botId}>`);
 
         if (isBotMentioned) {
-          // Strip the <@botId> mention to avoid visual clutter
+          // 視覚的なノイズを避けるため <@botId> メンションを除去する
           content = content
             .replace(new RegExp(`<@!?${botId}>`, 'g'), '')
             .trim();
-          // Prepend trigger if not already present
+          // トリガーがまだ先頭にない場合は付加する
           if (!TRIGGER_PATTERN.test(content)) {
             content = `@${ASSISTANT_NAME} ${content}`;
           }
         }
       }
 
-      // Handle attachments — store placeholders so the agent knows something was sent
+      // 添付ファイルを処理 — プレースホルダーを保存してエージェントに送信内容を伝える
       if (message.attachments.size > 0) {
         const attachmentDescriptions = [...message.attachments.values()].map(
           (att) => {
@@ -168,7 +168,7 @@ export class DiscordChannel implements Channel {
         }
       }
 
-      // Handle reply context — include who the user is replying to
+      // リプライ文脈を処理 — 誰への返信かを含める
       if (message.reference?.messageId) {
         try {
           const repliedTo = await message.channel.messages.fetch(
@@ -180,11 +180,11 @@ export class DiscordChannel implements Channel {
             repliedTo.author.username;
           content = `[Reply to ${replyAuthor}] ${content}`;
         } catch {
-          // Referenced message may have been deleted
+          // 参照元メッセージが削除されている可能性がある
         }
       }
 
-      // Store chat metadata for discovery
+      // 発見用にチャットメタデータを保存する
       const isGroup = message.guild !== null;
       this.opts.onChatMetadata(
         chatJid,
@@ -194,15 +194,15 @@ export class DiscordChannel implements Channel {
         isGroup,
       );
 
-      // Only deliver full message for registered groups.
-      // Exception: thread messages from channels whose parent has thread_defaults
-      // are allowed through so index.ts can auto-register the thread group.
+      // 登録済みグループのみ完全なメッセージを配信する。
+      // 例外: thread_defaults を持つ親チャンネルのスレッドメッセージは、
+      // index.ts がスレッドグループを自動登録できるよう通過させる。
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) {
         if (parentJid) {
           const parentGroup = this.opts.registeredGroups()[parentJid];
           if (parentGroup?.thread_defaults) {
-            // Auto-registration candidate — fall through to deliver the message
+            // 自動登録候補 — メッセージ配信をそのまま続行する
           } else {
             logger.debug(
               { chatJid, chatName },
@@ -219,9 +219,9 @@ export class DiscordChannel implements Channel {
         }
       }
 
-      // Deliver message — startMessageLoop() will pick it up.
-      // InboundMessage extends NewMessage with Discord-specific metadata
-      // (place_type, actor_role, is_thread, parent_jid) that is callback-only and not persisted.
+      // メッセージを配信 — startMessageLoop() が取得する。
+      // InboundMessage は NewMessage を拡張し、Discord 固有のメタデータ
+      // (place_type, actor_role, is_thread, parent_jid) を含むが、これらはコールバック専用で永続化されない。
       const inbound: InboundMessage = {
         id: msgId,
         chat_jid: chatJid,
@@ -243,7 +243,7 @@ export class DiscordChannel implements Channel {
       );
     });
 
-    // Handle errors gracefully
+    // エラーを適切に処理する
     this.client.on(Events.Error, (err) => {
       logger.error({ err: err.message }, 'Discord client error');
     });
@@ -292,7 +292,7 @@ export class DiscordChannel implements Channel {
 
       const textChannel = channel as TextChannel;
 
-      // Discord has a 2000 character limit per message — split if needed
+      // Discord は1メッセージあたり2000文字の制限がある — 必要に応じて分割する
       const MAX_LENGTH = 2000;
       if (text.length <= MAX_LENGTH) {
         await textChannel.send(text);

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -6,14 +6,14 @@ import {
   getRegisteredChannelNames,
 } from './registry.js';
 
-// The registry is module-level state, so we need a fresh module per test.
-// We use dynamic import with cache-busting to isolate tests.
-// However, since vitest runs each file in its own context and we control
-// registration order, we can test the public API directly.
+// レジストリはモジュールレベルの状態なので、テストごとに新しいモジュールが必要。
+// テストを分離するためにキャッシュバスティング付きの動的インポートを使用できる。
+// ただし vitest は各ファイルを独自のコンテキストで実行し、登録順序を制御できるため、
+// 公開APIを直接テストできる。
 
 describe('channel registry', () => {
-  // Note: registry is shared module state across tests in this file.
-  // Tests are ordered to account for cumulative registrations.
+  // 注: レジストリはこのファイルのテスト間で共有されるモジュール状態。
+  // 累積登録を考慮してテスト順序を調整している。
 
   it('getChannelFactory returns undefined for unknown channel', () => {
     expect(getChannelFactory('nonexistent')).toBeUndefined();

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 
-// Sentinel markers must match container-runner.ts
+// センチネルマーカーは container-runner.ts と一致させる必要があります
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
-// Mock config
+// config のモック
 vi.mock('./config.js', () => ({
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
   CONTAINER_MAX_OUTPUT_SIZE: 10485760,
@@ -18,7 +18,7 @@ vi.mock('./config.js', () => ({
   TIMEZONE: 'America/Los_Angeles',
 }));
 
-// Mock logger
+// logger のモック
 vi.mock('./logger.js', () => ({
   logger: {
     debug: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock('./logger.js', () => ({
   },
 }));
 
-// Mock fs
+// fs のモック
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
@@ -46,12 +46,12 @@ vi.mock('fs', async () => {
   };
 });
 
-// Mock mount-security
+// mount-security のモック
 vi.mock('./mount-security.js', () => ({
   validateAdditionalMounts: vi.fn(() => []),
 }));
 
-// Mock provider selection
+// プロバイダー選択のモック
 const mockContainerProviderEnv: Record<string, string> = {
   NANOCLAW_PROVIDER_CONFIG_JSON: JSON.stringify({
     providers: {
@@ -88,7 +88,7 @@ vi.mock('./provider-config.js', () => ({
   buildContainerProviderEnv: vi.fn(() => ({ ...mockContainerProviderEnv })),
 }));
 
-// Create a controllable fake ChildProcess
+// 制御可能な偽 ChildProcess を作成
 function createFakeProcess() {
   const proc = new EventEmitter() as EventEmitter & {
     stdin: PassThrough;
@@ -107,7 +107,7 @@ function createFakeProcess() {
 
 let fakeProc: ReturnType<typeof createFakeProcess>;
 
-// Mock child_process.spawn
+// child_process.spawn のモック
 vi.mock('child_process', async () => {
   const actual =
     await vi.importActual<typeof import('child_process')>('child_process');
@@ -186,23 +186,23 @@ describe('container-runner timeout behavior', () => {
       onOutput,
     );
 
-    // Emit output with a result
+    // 結果付きの出力を発行
     emitOutputMarker(fakeProc, {
       status: 'success',
       result: 'Here is my response',
       newSessionId: 'session-123',
     });
 
-    // Let output processing settle
+    // 出力処理が落ち着くまで待つ
     await vi.advanceTimersByTimeAsync(10);
 
-    // Fire the hard timeout (IDLE_TIMEOUT + 30s = 1830000ms)
+    // ハードタイムアウトを発火（IDLE_TIMEOUT + 30s = 1830000ms）
     await vi.advanceTimersByTimeAsync(1830000);
 
-    // Emit close event (as if container was stopped by the timeout)
+    // close イベントを発行（タイムアウトで停止された想定）
     fakeProc.emit('close', 137);
 
-    // Let the promise resolve
+    // Promise が解決されるまで待つ
     await vi.advanceTimersByTimeAsync(10);
 
     const result = await resultPromise;
@@ -222,10 +222,10 @@ describe('container-runner timeout behavior', () => {
       onOutput,
     );
 
-    // No output emitted — fire the hard timeout
+    // 出力なし — ハードタイムアウトを発火
     await vi.advanceTimersByTimeAsync(1830000);
 
-    // Emit close event
+    // close イベントを発行
     fakeProc.emit('close', 137);
 
     await vi.advanceTimersByTimeAsync(10);
@@ -245,7 +245,7 @@ describe('container-runner timeout behavior', () => {
       onOutput,
     );
 
-    // Emit output
+    // 出力を発行
     emitOutputMarker(fakeProc, {
       status: 'success',
       result: 'Done',
@@ -254,7 +254,7 @@ describe('container-runner timeout behavior', () => {
 
     await vi.advanceTimersByTimeAsync(10);
 
-    // Normal exit (no timeout)
+    // 通常終了（タイムアウトなし）
     fakeProc.emit('close', 0);
 
     await vi.advanceTimersByTimeAsync(10);

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock logger
+// logger のモック
 vi.mock('./logger.js', () => ({
   logger: {
     debug: vi.fn(),
@@ -10,7 +10,7 @@ vi.mock('./logger.js', () => ({
   },
 }));
 
-// Mock child_process — store the mock fn so tests can configure it
+// child_process のモック — テストで設定できるようモック関数を保持する
 const mockExecSync = vi.fn();
 vi.mock('child_process', () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
@@ -29,7 +29,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// --- Pure functions ---
+// --- 純粋関数 ---
 
 describe('readonlyMountArgs', () => {
   it('returns -v flag with :ro suffix', () => {
@@ -80,16 +80,16 @@ describe('ensureContainerRuntimeRunning', () => {
 
 describe('cleanupOrphans', () => {
   it('stops orphaned nanoclaw containers', () => {
-    // docker ps returns container names, one per line
+    // docker ps はコンテナ名を1行ずつ返す
     mockExecSync.mockReturnValueOnce(
       'nanoclaw-group1-111\nnanoclaw-group2-222\n',
     );
-    // stop calls succeed
+    // stop 呼び出しは成功する
     mockExecSync.mockReturnValue('');
 
     cleanupOrphans();
 
-    // ps + 2 stop calls
+    // ps + 2 回の stop 呼び出し
     expect(mockExecSync).toHaveBeenCalledTimes(3);
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
@@ -121,7 +121,7 @@ describe('cleanupOrphans', () => {
       throw new Error('docker not available');
     });
 
-    cleanupOrphans(); // should not throw
+    cleanupOrphans(); // スローしないこと
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
@@ -131,14 +131,14 @@ describe('cleanupOrphans', () => {
 
   it('continues stopping remaining containers when one stop fails', () => {
     mockExecSync.mockReturnValueOnce('nanoclaw-a-1\nnanoclaw-b-2\n');
-    // First stop fails
+    // 1 回目の stop が失敗
     mockExecSync.mockImplementationOnce(() => {
       throw new Error('already stopped');
     });
-    // Second stop succeeds
+    // 2 回目の stop が成功
     mockExecSync.mockReturnValueOnce('');
 
-    cleanupOrphans(); // should not throw
+    cleanupOrphans(); // スローしないこと
 
     expect(mockExecSync).toHaveBeenCalledTimes(3);
     expect(logger.info).toHaveBeenCalledWith(

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
   _initTestDatabase();
 });
 
-// Helper to store a message using the normalized NewMessage interface
+// 正規化された NewMessage インターフェースを使ってメッセージを保存するヘルパー
 function store(overrides: {
   id: string;
   chat_jid: string;
@@ -54,7 +54,7 @@ function store(overrides: {
   });
 }
 
-// --- storeMessage (NewMessage format) ---
+// --- storeMessage（NewMessage 形式）---
 
 describe('storeMessage', () => {
   it('stores a message and retrieves it', () => {
@@ -114,7 +114,7 @@ describe('storeMessage', () => {
       is_from_me: true,
     });
 
-    // Message is stored (we can retrieve it — is_from_me doesn't affect retrieval)
+    // メッセージは保存されている（取得可能 — is_from_me は取得に影響しない）
     const messages = getMessagesSince(
       'group@g.us',
       '2024-01-01T00:00:00.000Z',
@@ -201,7 +201,7 @@ describe('getMessagesSince', () => {
       '2024-01-01T00:00:02.000Z',
       'Andy',
     );
-    // Should exclude m1, m2 (before/at timestamp), m3 (bot message)
+    // m1、m2（タイムスタンプ以前）、m3（ボットメッセージ）を除外する必要がある
     expect(msgs).toHaveLength(1);
     expect(msgs[0].content).toBe('third');
   });
@@ -218,12 +218,12 @@ describe('getMessagesSince', () => {
 
   it('returns all non-bot messages when sinceTimestamp is empty', () => {
     const msgs = getMessagesSince('group@g.us', '', 'Andy');
-    // 3 user messages (bot message excluded)
+    // 3件のユーザーメッセージ（ボットメッセージは除外）
     expect(msgs).toHaveLength(3);
   });
 
   it('filters pre-migration bot messages via content prefix backstop', () => {
-    // Simulate a message written before migration: has prefix but is_bot_message = 0
+    // マイグレーション前に書かれたメッセージをシミュレート: プレフィックスがあるが is_bot_message = 0
     store({
       id: 'm5',
       chat_jid: 'group@g.us',
@@ -289,7 +289,7 @@ describe('getNewMessages', () => {
       '2024-01-01T00:00:00.000Z',
       'Andy',
     );
-    // Excludes bot message, returns 3 user messages
+    // ボットメッセージを除外し、3件のユーザーメッセージを返す
     expect(messages).toHaveLength(3);
     expect(newTimestamp).toBe('2024-01-01T00:00:04.000Z');
   });
@@ -300,7 +300,7 @@ describe('getNewMessages', () => {
       '2024-01-01T00:00:02.000Z',
       'Andy',
     );
-    // Only g1 msg2 (after ts, not bot)
+    // g1 msg2 のみ（ts 以降でボットではない）
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe('g1 msg2');
   });
@@ -405,7 +405,7 @@ describe('task CRUD', () => {
   });
 });
 
-// --- LIMIT behavior ---
+// --- LIMIT の挙動 ---
 
 describe('message query LIMIT', () => {
   beforeEach(() => {
@@ -433,9 +433,9 @@ describe('message query LIMIT', () => {
     expect(messages).toHaveLength(3);
     expect(messages[0].content).toBe('message 8');
     expect(messages[2].content).toBe('message 10');
-    // Chronological order preserved
+    // 時系列順が保持されている
     expect(messages[1].timestamp > messages[0].timestamp).toBe(true);
-    // newTimestamp reflects latest returned row
+    // newTimestamp は返却された最新の行を反映する
     expect(newTimestamp).toBe('2024-01-01T00:00:10.000Z');
   });
 
@@ -463,7 +463,7 @@ describe('message query LIMIT', () => {
   });
 });
 
-// --- RegisteredGroup GroupType round-trip ---
+// --- RegisteredGroup GroupType の往復 ---
 
 describe('registered group type', () => {
   it('persists type=main through set/get round-trip', () => {
@@ -634,7 +634,7 @@ describe('registered group type', () => {
   });
 });
 
-// --- Session accessors (jid-keyed) ---
+// --- Session アクセサ（jid をキーとする）---
 
 describe('session accessors', () => {
   it('sets and retrieves session by jid', () => {

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -112,7 +112,7 @@ describe('formatMessages', () => {
   });
 
   it('converts timestamps to local time for given timezone', () => {
-    // 2024-01-01T18:30:00Z in America/New_York (EST) = 1:30 PM
+    // 2024-01-01T18:30:00Z を America/New_York (EST) で変換すると 1:30 PM
     const result = formatMessages(
       [makeMsg({ timestamp: '2024-01-01T18:30:00.000Z' })],
       'America/New_York',
@@ -156,12 +156,12 @@ describe('TRIGGER_PATTERN', () => {
   });
 
   it('matches with leading whitespace after trim', () => {
-    // The actual usage trims before testing: TRIGGER_PATTERN.test(m.content.trim())
+    // 実際の使用ではテスト前に trim している: TRIGGER_PATTERN.test(m.content.trim())
     expect(TRIGGER_PATTERN.test(`@${name} hey`.trim())).toBe(true);
   });
 });
 
-// --- Outbound formatting (internal tag stripping + prefix) ---
+// --- 送信フォーマット（内部タグ除去 + プレフィックス）---
 
 describe('stripInternalTags', () => {
   it('strips single-line internal tags', () => {
@@ -203,11 +203,11 @@ describe('formatOutbound', () => {
   });
 });
 
-// --- Trigger gating with requiresTrigger flag ---
+// --- requiresTrigger フラグによるトリガーゲーティング ---
 
 describe('trigger gating (requiresTrigger interaction)', () => {
-  // Replicates the exact logic from processGroupMessages and startMessageLoop:
-  //   if (!isMainGroup && group.requiresTrigger !== false) { check trigger }
+  // processGroupMessages と startMessageLoop の正確なロジックを再現:
+  //   if (!isMainGroup && group.requiresTrigger !== false) { トリガーチェック }
   function shouldRequireTrigger(
     isMainGroup: boolean,
     requiresTrigger: boolean | undefined,

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 import { GroupQueue } from './group-queue.js';
 
-// Mock config to control concurrency limit
+// 並行数制限をコントロールするための設定モック
 vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/nanoclaw-test-data',
   MAX_CONCURRENT_CONTAINERS: 2,
 }));
 
-// Mock fs operations used by sendMessage/closeStdin
+// sendMessage/closeStdin で使用される fs 操作のモック
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
@@ -34,7 +34,7 @@ describe('GroupQueue', () => {
     vi.useRealTimers();
   });
 
-  // --- Single group at a time ---
+  // --- 同一グループは一度に1つだけ ---
 
   it('only runs one container per group at a time', async () => {
     let concurrentCount = 0;
@@ -43,7 +43,7 @@ describe('GroupQueue', () => {
     const processMessages = vi.fn(async (groupJid: string) => {
       concurrentCount++;
       maxConcurrent = Math.max(maxConcurrent, concurrentCount);
-      // Simulate async work
+      // 非同期処理をシミュレート
       await new Promise((resolve) => setTimeout(resolve, 100));
       concurrentCount--;
       return true;
@@ -51,18 +51,18 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Enqueue two messages for the same group
+    // 同一グループに2件のメッセージをキューに入れる
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group1@g.us');
 
-    // Advance timers to let the first process complete
+    // 最初の処理が完了するようにタイマーを進める
     await vi.advanceTimersByTimeAsync(200);
 
-    // Second enqueue should have been queued, not concurrent
+    // 2回目のエンキューは並行ではなくキューに入っている必要がある
     expect(maxConcurrent).toBe(1);
   });
 
-  // --- Global concurrency limit ---
+  // --- グローバル並行数制限 ---
 
   it('respects global concurrency limit', async () => {
     let activeCount = 0;
@@ -79,26 +79,26 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Enqueue 3 groups (limit is 2)
+    // 3グループをエンキュー（制限は2）
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
     queue.enqueueMessageCheck('group3@g.us');
 
-    // Let promises settle
+    // Promise を確定させる
     await vi.advanceTimersByTimeAsync(10);
 
-    // Only 2 should be active (MAX_CONCURRENT_CONTAINERS = 2)
+    // アクティブなのは2つだけ（MAX_CONCURRENT_CONTAINERS = 2）
     expect(maxActive).toBe(2);
     expect(activeCount).toBe(2);
 
-    // Complete one — third should start
+    // 1つ完了 — 3つ目が開始される必要がある
     completionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
     expect(processMessages).toHaveBeenCalledTimes(3);
   });
 
-  // --- Tasks prioritized over messages ---
+  // --- メッセージよりタスクを優先 ---
 
   it('drains tasks before messages for same group', async () => {
     const executionOrder: string[] = [];
@@ -106,7 +106,7 @@ describe('GroupQueue', () => {
 
     const processMessages = vi.fn(async (groupJid: string) => {
       if (executionOrder.length === 0) {
-        // First call: block until we release it
+        // 最初の呼び出し: 解放するまでブロック
         await new Promise<void>((resolve) => {
           resolveFirst = resolve;
         });
@@ -117,28 +117,28 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Start processing messages (takes the active slot)
+    // メッセージ処理を開始（アクティブスロットを占有）
     queue.enqueueMessageCheck('group1@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // While active, enqueue both a task and pending messages
+    // アクティブ中にタスクと保留中のメッセージを両方エンキュー
     const taskFn = vi.fn(async () => {
       executionOrder.push('task');
     });
     queue.enqueueTask('group1@g.us', 'task-1', taskFn);
     queue.enqueueMessageCheck('group1@g.us');
 
-    // Release the first processing
+    // 最初の処理を解放
     resolveFirst!();
     await vi.advanceTimersByTimeAsync(10);
 
-    // Task should have run before the second message check
-    expect(executionOrder[0]).toBe('messages'); // first call
-    expect(executionOrder[1]).toBe('task'); // task runs first in drain
-    // Messages would run after task completes
+    // タスクは2回目のメッセージチェックより前に実行される必要がある
+    expect(executionOrder[0]).toBe('messages'); // 最初の呼び出し
+    expect(executionOrder[1]).toBe('task'); // タスクが drain で最初に実行される
+    // メッセージはタスク完了後に実行される
   });
 
-  // --- Retry with backoff on failure ---
+  // --- 失敗時の指数バックオフによるリトライ ---
 
   it('retries with exponential backoff on failure', async () => {
     let callCount = 0;
@@ -151,22 +151,22 @@ describe('GroupQueue', () => {
     queue.setProcessMessagesFn(processMessages);
     queue.enqueueMessageCheck('group1@g.us');
 
-    // First call happens immediately
+    // 最初の呼び出しは即座に行われる
     await vi.advanceTimersByTimeAsync(10);
     expect(callCount).toBe(1);
 
-    // First retry after 5000ms (BASE_RETRY_MS * 2^0)
+    // 最初のリトライは 5000ms 後（BASE_RETRY_MS * 2^0）
     await vi.advanceTimersByTimeAsync(5000);
     await vi.advanceTimersByTimeAsync(10);
     expect(callCount).toBe(2);
 
-    // Second retry after 10000ms (BASE_RETRY_MS * 2^1)
+    // 2回目のリトライは 10000ms 後（BASE_RETRY_MS * 2^1）
     await vi.advanceTimersByTimeAsync(10000);
     await vi.advanceTimersByTimeAsync(10);
     expect(callCount).toBe(3);
   });
 
-  // --- Shutdown prevents new enqueues ---
+  // --- シャットダウン後は新規エンキューを防ぐ ---
 
   it('prevents new enqueues after shutdown', async () => {
     const processMessages = vi.fn(async () => true);
@@ -180,7 +180,7 @@ describe('GroupQueue', () => {
     expect(processMessages).not.toHaveBeenCalled();
   });
 
-  // --- Max retries exceeded ---
+  // --- 最大リトライ回数超過 ---
 
   it('stops retrying after MAX_RETRIES and resets', async () => {
     let callCount = 0;
@@ -193,25 +193,25 @@ describe('GroupQueue', () => {
     queue.setProcessMessagesFn(processMessages);
     queue.enqueueMessageCheck('group1@g.us');
 
-    // Run through all 5 retries (MAX_RETRIES = 5)
-    // Initial call
+    // すべての5回のリトライを実行（MAX_RETRIES = 5）
+    // 初回呼び出し
     await vi.advanceTimersByTimeAsync(10);
     expect(callCount).toBe(1);
 
-    // Retry 1: 5000ms, Retry 2: 10000ms, Retry 3: 20000ms, Retry 4: 40000ms, Retry 5: 80000ms
+    // リトライ 1: 5000ms、リトライ 2: 10000ms、リトライ 3: 20000ms、リトライ 4: 40000ms、リトライ 5: 80000ms
     const retryDelays = [5000, 10000, 20000, 40000, 80000];
     for (let i = 0; i < retryDelays.length; i++) {
       await vi.advanceTimersByTimeAsync(retryDelays[i] + 10);
       expect(callCount).toBe(i + 2);
     }
 
-    // After 5 retries (6 total calls), should stop — no more retries
+    // 5回のリトライ後（合計6回呼び出し）、停止する — それ以上リトライしない
     const countAfterMaxRetries = callCount;
-    await vi.advanceTimersByTimeAsync(200000); // Wait a long time
+    await vi.advanceTimersByTimeAsync(200000); // 長時間待機
     expect(callCount).toBe(countAfterMaxRetries);
   });
 
-  // --- Waiting groups get drained when slots free up ---
+  // --- スロットが空くと待機中のグループが処理される ---
 
   it('drains waiting groups when active slots free up', async () => {
     const processed: string[] = [];
@@ -225,25 +225,25 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Fill both slots
+    // 両方のスロットを埋める
     queue.enqueueMessageCheck('group1@g.us');
     queue.enqueueMessageCheck('group2@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // Queue a third
+    // 3つ目をキューに入れる
     queue.enqueueMessageCheck('group3@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
     expect(processed).toEqual(['group1@g.us', 'group2@g.us']);
 
-    // Free up a slot
+    // スロットを1つ空ける
     completionCallbacks[0]();
     await vi.advanceTimersByTimeAsync(10);
 
     expect(processed).toContain('group3@g.us');
   });
 
-  // --- Running task dedup (Issue #138) ---
+  // --- 実行中タスクの重複排除（Issue #138）---
 
   it('rejects duplicate enqueue of a currently-running task', async () => {
     let resolveTask: () => void;
@@ -256,29 +256,29 @@ describe('GroupQueue', () => {
       });
     });
 
-    // Start the task (runs immediately — slot available)
+    // タスクを開始（スロットが空いているため即座に実行）
     queue.enqueueTask('group1@g.us', 'task-1', taskFn);
     await vi.advanceTimersByTimeAsync(10);
     expect(taskCallCount).toBe(1);
 
-    // Scheduler poll re-discovers the same task while it's running —
-    // this must be silently dropped
+    // スケジューラーのポーリングでタスク実行中に同一タスクが再発見された場合 —
+    // これは静かに破棄される必要がある
     const dupFn = vi.fn(async () => {});
     queue.enqueueTask('group1@g.us', 'task-1', dupFn);
     await vi.advanceTimersByTimeAsync(10);
 
-    // Duplicate was NOT queued
+    // 重複はキューに入れられなかった
     expect(dupFn).not.toHaveBeenCalled();
 
-    // Complete the original task
+    // 元のタスクを完了させる
     resolveTask!();
     await vi.advanceTimersByTimeAsync(10);
 
-    // Only one execution total
+    // 合計で1回のみ実行
     expect(taskCallCount).toBe(1);
   });
 
-  // --- Idle preemption ---
+  // --- アイドル時のプリエンプション ---
 
   it('does NOT preempt active container when not idle', async () => {
     const fs = await import('fs');
@@ -293,18 +293,18 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Start processing (takes the active slot)
+    // 処理を開始（アクティブスロットを占有）
     queue.enqueueMessageCheck('group1@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // Register a process so closeStdin has an active container context
+    // closeStdin がアクティブなコンテナコンテキストを持つようにプロセスを登録
     queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
-    // Enqueue a task while container is active but NOT idle
+    // コンテナがアクティブだがアイドルでない間にタスクをエンキュー
     const taskFn = vi.fn(async () => {});
     queue.enqueueTask('group1@g.us', 'task-1', taskFn);
 
-    // _close should NOT have been written (container is working, not idle)
+    // _close は書き込まれていない必要がある（コンテナは作業中でアイドルではない）
     const writeFileSync = vi.mocked(fs.default.writeFileSync);
     const closeWrites = writeFileSync.mock.calls.filter(
       (call) => typeof call[0] === 'string' && call[0].endsWith('_close'),
@@ -328,22 +328,22 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Start processing
+    // 処理を開始
     queue.enqueueMessageCheck('group1@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // Register process and mark idle
+    // プロセスを登録しアイドル状態にする
     queue.registerProcess('group1@g.us', {} as any, 'container-1');
     queue.notifyIdle('group1@g.us');
 
-    // Clear previous writes, then enqueue a task
+    // 以前の書き込みをクリアしてからタスクをエンキュー
     const writeFileSync = vi.mocked(fs.default.writeFileSync);
     writeFileSync.mockClear();
 
     const taskFn = vi.fn(async () => {});
     queue.enqueueTask('group1@g.us', 'task-1', taskFn);
 
-    // _close SHOULD have been written (container is idle)
+    // _close が書き込まれている必要がある（コンテナはアイドル）
     const closeWrites = writeFileSync.mock.calls.filter(
       (call) => typeof call[0] === 'string' && call[0].endsWith('_close'),
     );
@@ -369,13 +369,13 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
     queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
-    // Container becomes idle
+    // コンテナがアイドル状態になる
     queue.notifyIdle('group1@g.us');
 
-    // A new user message arrives — resets idleWaiting
+    // 新しいユーザーメッセージが到着 — idleWaiting をリセット
     queue.sendMessage('group1@g.us', 'hello');
 
-    // Task enqueued after message reset — should NOT preempt (agent is working)
+    // メッセージリセット後にエンキューされたタスク — プリエンプトしない（エージェントは作業中）
     const writeFileSync = vi.mocked(fs.default.writeFileSync);
     writeFileSync.mockClear();
 
@@ -400,12 +400,12 @@ describe('GroupQueue', () => {
       });
     });
 
-    // Start a task (sets isTaskContainer = true)
+    // タスクを開始（isTaskContainer = true に設定）
     queue.enqueueTask('group1@g.us', 'task-1', taskFn);
     await vi.advanceTimersByTimeAsync(10);
     queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
-    // sendMessage should return false — user messages must not go to task containers
+    // sendMessage は false を返す必要がある — ユーザーメッセージはタスクコンテナに送られてはいけない
     const result = queue.sendMessage('group1@g.us', 'hello');
     expect(result).toBe(false);
 
@@ -426,11 +426,11 @@ describe('GroupQueue', () => {
 
     queue.setProcessMessagesFn(processMessages);
 
-    // Start processing
+    // 処理を開始
     queue.enqueueMessageCheck('group1@g.us');
     await vi.advanceTimersByTimeAsync(10);
 
-    // Register process and enqueue a task (no idle yet — no preemption)
+    // プロセスを登録しタスクをエンキュー（まだアイドルでない — プリエンプトなし）
     queue.registerProcess('group1@g.us', {} as any, 'container-1');
 
     const writeFileSync = vi.mocked(fs.default.writeFileSync);
@@ -444,7 +444,7 @@ describe('GroupQueue', () => {
     );
     expect(closeWrites).toHaveLength(0);
 
-    // Now container becomes idle — should preempt because task is pending
+    // コンテナがアイドルになった — 保留中のタスクがあるためプリエンプトする必要がある
     writeFileSync.mockClear();
     queue.notifyIdle('group1@g.us');
 

--- a/src/ipc-auth.test.ts
+++ b/src/ipc-auth.test.ts
@@ -12,7 +12,7 @@ import {
 import { processTaskIpc, IpcDeps } from './ipc.js';
 import { RegisteredGroup } from './types.js';
 
-// Set up registered groups used across tests
+// テスト全体で使用する登録済みグループを設定
 const MAIN_GROUP: RegisteredGroup = {
   name: 'Main',
   folder: 'discord_main',
@@ -47,7 +47,7 @@ beforeEach(() => {
     'dc:third': THIRD_GROUP,
   };
 
-  // Populate DB as well
+  // DB も同様に初期化
   setRegisteredGroup('dc:main', MAIN_GROUP);
   setRegisteredGroup('dc:other', OTHER_GROUP);
   setRegisteredGroup('dc:third', THIRD_GROUP);
@@ -58,7 +58,7 @@ beforeEach(() => {
     registerGroup: (jid, group) => {
       groups[jid] = group;
       setRegisteredGroup(jid, group);
-      // Mock the fs.mkdirSync that registerGroup does
+      // registerGroup 内で呼ばれる fs.mkdirSync をモック
     },
     syncGroups: async () => {},
     getAvailableGroups: () => [],
@@ -66,7 +66,7 @@ beforeEach(() => {
   };
 });
 
-// --- schedule_task authorization ---
+// --- schedule_task の認可 ---
 
 describe('schedule_task authorization', () => {
   it('main group can schedule for another group', async () => {
@@ -83,7 +83,7 @@ describe('schedule_task authorization', () => {
       deps,
     );
 
-    // Verify task was created in DB for the other group
+    // 他のグループ用に DB にタスクが作成されたことを確認
     const allTasks = getAllTasks();
     expect(allTasks.length).toBe(1);
     expect(allTasks[0].group_folder).toBe('other-group');
@@ -145,7 +145,7 @@ describe('schedule_task authorization', () => {
   });
 });
 
-// --- pause_task authorization ---
+// --- pause_task の認可 ---
 
 describe('pause_task authorization', () => {
   beforeEach(() => {
@@ -206,7 +206,7 @@ describe('pause_task authorization', () => {
   });
 });
 
-// --- resume_task authorization ---
+// --- resume_task の認可 ---
 
 describe('resume_task authorization', () => {
   beforeEach(() => {
@@ -255,7 +255,7 @@ describe('resume_task authorization', () => {
   });
 });
 
-// --- cancel_task authorization ---
+// --- cancel_task の認可 ---
 
 describe('cancel_task authorization', () => {
   it('main group can cancel any task', async () => {
@@ -328,7 +328,7 @@ describe('cancel_task authorization', () => {
   });
 });
 
-// --- register_group authorization ---
+// --- register_group の認可 ---
 
 describe('register_group authorization', () => {
   it('non-main group cannot register a group', async () => {
@@ -345,7 +345,7 @@ describe('register_group authorization', () => {
       deps,
     );
 
-    // registeredGroups should not have changed
+    // registeredGroups は変更されていないはず
     expect(groups['dc:new']).toBeUndefined();
   });
 
@@ -367,22 +367,22 @@ describe('register_group authorization', () => {
   });
 });
 
-// --- refresh_groups authorization ---
+// --- refresh_groups の認可 ---
 
 describe('refresh_groups authorization', () => {
   it('non-main group cannot trigger refresh', async () => {
-    // This should be silently blocked (no crash, no effect)
+    // これは静かにブロックされるべき（クラッシュも効果もない）
     await processTaskIpc({ type: 'refresh_groups' }, 'dc:other', false, deps);
-    // If we got here without error, the auth gate worked
+    // エラーなしでここまで来たら認可ゲートが機能した
   });
 });
 
-// --- IPC message authorization ---
-// Tests the authorization pattern from startIpcWatcher (ipc.ts).
-// The logic: isPrivileged || targetChatJid === sourceChatJid
+// --- IPC メッセージの認可 ---
+// ipc.ts の startIpcWatcher の認可パターンをテスト
+// ロジック: isPrivileged || targetChatJid === sourceChatJid
 
 describe('IPC message authorization', () => {
-  // Replicate the exact check from the IPC watcher
+  // IPC ウォッチャーの正確なチェックを再現
   function isMessageAuthorized(
     sourceChatJid: string,
     isPrivileged: boolean,
@@ -415,7 +415,7 @@ describe('IPC message authorization', () => {
   });
 });
 
-// --- schedule_task with cron and interval types ---
+// --- cron と interval タイプの schedule_task ---
 
 describe('schedule_task schedule types', () => {
   it('creates task with cron schedule and computes next_run', async () => {
@@ -424,7 +424,7 @@ describe('schedule_task schedule types', () => {
         type: 'schedule_task',
         prompt: 'cron task',
         schedule_type: 'cron',
-        schedule_value: '0 9 * * *', // every day at 9am
+        schedule_value: '0 9 * * *', // 毎日午前9時
         targetJid: 'dc:other',
       },
       'dc:main',
@@ -436,7 +436,7 @@ describe('schedule_task schedule types', () => {
     expect(tasks).toHaveLength(1);
     expect(tasks[0].schedule_type).toBe('cron');
     expect(tasks[0].next_run).toBeTruthy();
-    // next_run should be a valid ISO date in the future
+    // next_run は将来の有効な ISO 日付であるべき
     expect(new Date(tasks[0].next_run!).getTime()).toBeGreaterThan(
       Date.now() - 60000,
     );
@@ -467,7 +467,7 @@ describe('schedule_task schedule types', () => {
         type: 'schedule_task',
         prompt: 'interval task',
         schedule_type: 'interval',
-        schedule_value: '3600000', // 1 hour
+        schedule_value: '3600000', // 1時間
         targetJid: 'dc:other',
       },
       'dc:main',
@@ -478,7 +478,7 @@ describe('schedule_task schedule types', () => {
     const tasks = getAllTasks();
     expect(tasks).toHaveLength(1);
     expect(tasks[0].schedule_type).toBe('interval');
-    // next_run should be ~1 hour from now
+    // next_run は今から約1時間後であるべき
     const nextRun = new Date(tasks[0].next_run!).getTime();
     expect(nextRun).toBeGreaterThanOrEqual(before + 3600000 - 1000);
     expect(nextRun).toBeLessThanOrEqual(Date.now() + 3600000 + 1000);
@@ -536,7 +536,7 @@ describe('schedule_task schedule types', () => {
   });
 });
 
-// --- context_mode defaulting ---
+// --- context_mode のデフォルト値 ---
 
 describe('schedule_task context_mode', () => {
   it('accepts context_mode=group', async () => {
@@ -615,7 +615,7 @@ describe('schedule_task context_mode', () => {
   });
 });
 
-// --- register_group success path ---
+// --- register_group の成功パス ---
 
 describe('register_group success', () => {
   it('main group can register a new group', async () => {
@@ -632,7 +632,7 @@ describe('register_group success', () => {
       deps,
     );
 
-    // Verify group was registered in DB
+    // グループが DB に登録されたことを確認
     const group = getRegisteredGroup('dc:new');
     expect(group).toBeDefined();
     expect(group!.name).toBe('New Group');
@@ -646,7 +646,7 @@ describe('register_group success', () => {
         type: 'register_group',
         jid: 'dc:partial',
         name: 'Partial',
-        // missing folder and trigger
+        // folder と trigger が欠落
       },
       'dc:main',
       true,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -45,7 +45,7 @@ function parseIpcChannelMode(
   }
 
   if (typeof value === 'string') {
-    // Legacy alias: url_watch → thread_per_message
+    // 旧エイリアス: url_watch → thread_per_message
     if (value === 'url_watch') {
       return 'thread_per_message';
     }

--- a/src/remote-control.test.ts
+++ b/src/remote-control.test.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-// Mock config before importing the module under test
+// テスト対象モジュールをインポートする前に config をモック化
 vi.mock('./config.js', () => ({
   DATA_DIR: '/tmp/nanoclaw-rc-test',
 }));
 
-// Mock child_process
+// child_process をモック化
 const spawnMock = vi.fn();
 vi.mock('child_process', () => ({
   spawn: (...args: any[]) => spawnMock(...args),
@@ -21,7 +21,7 @@ import {
   _getStateFilePath,
 } from './remote-control.js';
 
-// --- Helpers ---
+// --- ヘルパー ---
 
 function createMockProcess(pid = 12345) {
   return {
@@ -41,7 +41,7 @@ describe('remote-control', () => {
   let openSyncSpy: ReturnType<typeof vi.spyOn>;
   let closeSyncSpy: ReturnType<typeof vi.spyOn>;
 
-  // Track what readFileSync should return for the stdout file
+  // readFileSync が stdout ファイルに対して返すべき内容を追跡する
   let stdoutFileContent: string;
 
   beforeEach(() => {
@@ -49,7 +49,7 @@ describe('remote-control', () => {
     spawnMock.mockReset();
     stdoutFileContent = '';
 
-    // Default fs mocks
+    // デフォルトの fs モック
     mkdirSyncSpy = vi
       .spyOn(fs, 'mkdirSync')
       .mockImplementation(() => undefined as any);
@@ -60,7 +60,7 @@ describe('remote-control', () => {
     openSyncSpy = vi.spyOn(fs, 'openSync').mockReturnValue(42 as any);
     closeSyncSpy = vi.spyOn(fs, 'closeSync').mockImplementation(() => {});
 
-    // readFileSync: return stdoutFileContent for the stdout file, state file, etc.
+    // readFileSync: stdout ファイルや状態ファイルなどに対して stdoutFileContent を返す
     readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(((
       p: string,
     ) => {
@@ -77,14 +77,14 @@ describe('remote-control', () => {
     vi.restoreAllMocks();
   });
 
-  // --- startRemoteControl ---
+  // --- startRemoteControl のテスト ---
 
   describe('startRemoteControl', () => {
     it('spawns claude remote-control and returns the URL', async () => {
       const proc = createMockProcess();
       spawnMock.mockReturnValue(proc);
 
-      // Simulate URL appearing in stdout file on first poll
+      // 最初のポーリングで stdout ファイルに URL が出現するのをシミュレート
       stdoutFileContent =
         'Session URL: https://claude.ai/code?bridge=env_abc123\n';
       vi.spyOn(process, 'kill').mockImplementation((() => true) as any);
@@ -113,7 +113,7 @@ describe('remote-control', () => {
 
       const spawnCall = spawnMock.mock.calls[0];
       const options = spawnCall[2];
-      // stdio[0] is 'pipe' so we can write 'y' to accept the prompt
+      // stdio[0] は 'pipe' なので、プロンプトに 'y' を書き込める
       expect(options.stdio[0]).toBe('pipe');
       expect(typeof options.stdio[1]).toBe('number');
       expect(typeof options.stdio[2]).toBe('number');
@@ -127,7 +127,7 @@ describe('remote-control', () => {
 
       await startRemoteControl('user1', 'tg:123', '/project');
 
-      // Two openSync calls (stdout + stderr), two closeSync calls
+      // openSync が2回（stdout + stderr）、closeSync が2回呼ばれる
       expect(openSyncSpy).toHaveBeenCalledTimes(2);
       expect(closeSyncSpy).toHaveBeenCalledTimes(2);
     });
@@ -154,7 +154,7 @@ describe('remote-control', () => {
 
       await startRemoteControl('user1', 'tg:123', '/project');
 
-      // Second call should return existing URL without spawning
+      // 2回目の呼び出しでは、新規起動せずに既存の URL を返すべき
       const result = await startRemoteControl('user2', 'tg:456', '/project');
       expect(result).toEqual({
         ok: true,
@@ -168,14 +168,14 @@ describe('remote-control', () => {
       const proc2 = createMockProcess(22222);
       spawnMock.mockReturnValueOnce(proc1).mockReturnValueOnce(proc2);
 
-      // First start: process alive, URL found
+      // 最初の起動: プロセスは生存、URL が見つかる
       const killSpy = vi
         .spyOn(process, 'kill')
         .mockImplementation((() => true) as any);
       stdoutFileContent = 'https://claude.ai/code?bridge=env_first\n';
       await startRemoteControl('user1', 'tg:123', '/project');
 
-      // Old process (11111) is dead, new process (22222) is alive
+      // 古いプロセス（11111）は終了、新しいプロセス（22222）は生存
       killSpy.mockImplementation(((pid: number, sig: any) => {
         if (pid === 11111 && (sig === 0 || sig === undefined)) {
           throw new Error('ESRCH');
@@ -198,7 +198,7 @@ describe('remote-control', () => {
       spawnMock.mockReturnValue(proc);
       stdoutFileContent = '';
 
-      // Process is dead (poll will detect this)
+      // プロセスは終了している（ポーリングで検出される）
       vi.spyOn(process, 'kill').mockImplementation((() => {
         throw new Error('ESRCH');
       }) as any);
@@ -219,7 +219,7 @@ describe('remote-control', () => {
 
       const promise = startRemoteControl('user1', 'tg:123', '/project');
 
-      // Advance past URL_TIMEOUT_MS (30s), with enough steps for polls
+      // URL_TIMEOUT_MS（30秒）を超過するまで、十分なポーリング回数で進める
       for (let i = 0; i < 160; i++) {
         await vi.advanceTimersByTimeAsync(200);
       }
@@ -246,7 +246,7 @@ describe('remote-control', () => {
     });
   });
 
-  // --- stopRemoteControl ---
+  // --- stopRemoteControl のテスト ---
 
   describe('stopRemoteControl', () => {
     it('kills the process and clears state', async () => {
@@ -275,7 +275,7 @@ describe('remote-control', () => {
     });
   });
 
-  // --- restoreRemoteControl ---
+  // --- restoreRemoteControl のテスト ---
 
   describe('restoreRemoteControl', () => {
     it('restores session if state file exists and process is alive', () => {
@@ -323,7 +323,7 @@ describe('remote-control', () => {
     });
 
     it('does nothing if no state file exists', () => {
-      // readFileSyncSpy default throws ENOENT for .json
+      // readFileSyncSpy はデフォルトで .json に対して ENOENT を投げる
       restoreRemoteControl();
       expect(getActiveSession()).toBeNull();
     });
@@ -340,7 +340,7 @@ describe('remote-control', () => {
       expect(unlinkSyncSpy).toHaveBeenCalled();
     });
 
-    // ** This is the key integration test: restore → stop must work **
+    // ** これは重要な統合テスト: restore → stop が必ず動作すること **
     it('stopRemoteControl works after restoreRemoteControl', () => {
       const session = {
         pid: 77777,

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   _setRegisteredGroups({});
 });
 
-// --- JID ownership patterns ---
+// --- JID 所有パターン ---
 
 describe('JID ownership patterns', () => {
   it('Discord JID: starts with dc:', () => {
@@ -17,7 +17,7 @@ describe('JID ownership patterns', () => {
   });
 });
 
-// --- getAvailableGroups ---
+// --- getAvailableGroups のテスト ---
 
 describe('getAvailableGroups', () => {
   it('returns only groups, excludes DMs', () => {
@@ -128,9 +128,9 @@ describe('getAvailableGroups', () => {
   });
 
   it('excludes non-group chats regardless of JID format', () => {
-    // Unknown JID format stored without is_group should not appear
+    // is_group なしで保存された不明な JID 形式は表示されないべき
     storeChatMetadata('unknown-format', '2024-01-01T00:00:01.000Z', 'Unknown');
-    // Explicitly non-group with unusual JID
+    // 明示的に非グループで珍しい JID
     storeChatMetadata(
       'other:abc',
       '2024-01-01T00:00:02.000Z',
@@ -138,7 +138,7 @@ describe('getAvailableGroups', () => {
       'custom',
       false,
     );
-    // A real group for contrast
+    // 対比用の実際のグループ
     storeChatMetadata(
       'dc:group',
       '2024-01-01T00:00:03.000Z',

--- a/src/sender-allowlist.test.ts
+++ b/src/sender-allowlist.test.ts
@@ -98,7 +98,7 @@ describe('loadSenderAllowlist', () => {
       chats: {},
     });
     const cfg = loadSenderAllowlist(p);
-    expect(cfg.default.allow).toBe('*'); // falls back to default
+    expect(cfg.default.allow).toBe('*'); // デフォルトにフォールバック
   });
 
   it('skips invalid per-chat entries', () => {
@@ -211,6 +211,6 @@ describe('isTriggerAllowed', () => {
       logDenied: true,
     };
     isTriggerAllowed('g1', 'eve', cfg);
-    // Logger.debug is called — we just verify no crash; logger is a real pino instance
+    // Logger.debug が呼ばれる — クラッシュしないことを確認するだけ; logger は実際の pino インスタンス
   });
 });

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -18,7 +18,7 @@ describe('task scheduler', () => {
     vi.useRealTimers();
   });
 
-  it('pauses due tasks with invalid group folders to prevent retry churn', async () => {
+  it('無効なグループフォルダを持つ期限タスクを一時停止し、リトライの繰り返しを防ぐ', async () => {
     createTask({
       id: 'task-invalid-folder',
       group_folder: '../../outside',
@@ -52,7 +52,7 @@ describe('task scheduler', () => {
     expect(task?.status).toBe('paused');
   });
 
-  it('computeNextRun anchors interval tasks to scheduled time to prevent drift', () => {
+  it('computeNextRun はインターバルタスクを予定時刻に固定し、ドリフトを防ぐ', () => {
     const scheduledTime = new Date(Date.now() - 2000).toISOString(); // 2s ago
     const task = {
       id: 'drift-test',
@@ -72,12 +72,12 @@ describe('task scheduler', () => {
     const nextRun = computeNextRun(task);
     expect(nextRun).not.toBeNull();
 
-    // Should be anchored to scheduledTime + 60s, NOT Date.now() + 60s
+    // scheduledTime + 60s に固定されるべきで、Date.now() + 60s ではない
     const expected = new Date(scheduledTime).getTime() + 60000;
     expect(new Date(nextRun!).getTime()).toBe(expected);
   });
 
-  it('computeNextRun returns null for once-tasks', () => {
+  it('computeNextRun は once タスクに対して null を返す', () => {
     const task = {
       id: 'once-test',
       group_folder: 'test',
@@ -96,8 +96,8 @@ describe('task scheduler', () => {
     expect(computeNextRun(task)).toBeNull();
   });
 
-  it('computeNextRun skips missed intervals without infinite loop', () => {
-    // Task was due 10 intervals ago (missed)
+  it('computeNextRun は逃したインターバルを無限ループなくスキップする', () => {
+    // タスクは 10 インターバル前に期限だった（逃した）
     const ms = 60000;
     const missedBy = ms * 10;
     const scheduledTime = new Date(Date.now() - missedBy).toISOString();
@@ -119,9 +119,9 @@ describe('task scheduler', () => {
 
     const nextRun = computeNextRun(task);
     expect(nextRun).not.toBeNull();
-    // Must be in the future
+    // 未来の時刻でなければならない
     expect(new Date(nextRun!).getTime()).toBeGreaterThan(Date.now());
-    // Must be aligned to the original schedule grid
+    // 元のスケジュールグリッドに揃っていなければならない
     const offset =
       (new Date(nextRun!).getTime() - new Date(scheduledTime).getTime()) % ms;
     expect(offset).toBe(0);

--- a/src/thread-auto-register.test.ts
+++ b/src/thread-auto-register.test.ts
@@ -65,7 +65,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     vi.clearAllMocks();
   });
 
-  it('creates a child group entry in registeredGroups', () => {
+  it('registeredGroups に子グループのエントリを作成する', () => {
     const msg: InboundMessage = {
       id: 'msg1',
       chat_jid: threadJid,
@@ -81,7 +81,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     expect(registeredGroups[threadJid]).toBeDefined();
   });
 
-  it('auto-registered child group reflects thread_defaults.type (chat)', () => {
+  it('自動登録された子グループは thread_defaults.type（chat）を反映する', () => {
     const parentWithChatType: RegisteredGroup = {
       ...parent,
       thread_defaults: { type: 'chat', requiresTrigger: false },
@@ -105,7 +105,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     );
   });
 
-  it('child group inherits folder from parent', () => {
+  it('子グループは親からフォルダを継承する', () => {
     const msg: InboundMessage = {
       id: 'msg3',
       chat_jid: threadJid,
@@ -121,7 +121,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     expect(registeredGroups[threadJid].folder).toBe(parent.folder);
   });
 
-  it('persists child group via setRegisteredGroup', () => {
+  it('setRegisteredGroup 経由で子グループを永続化する', () => {
     const msg: InboundMessage = {
       id: 'msg4',
       chat_jid: threadJid,
@@ -140,7 +140,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     );
   });
 
-  it('child group requiresTrigger inherits from thread_defaults', () => {
+  it('子グループの requiresTrigger は thread_defaults から継承される', () => {
     const parentWithTrigger: RegisteredGroup = {
       ...parent,
       thread_defaults: { type: 'thread', requiresTrigger: true },
@@ -160,7 +160,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     expect(registeredGroups[threadJid].requiresTrigger).toBe(true);
   });
 
-  it('does not create a privileged group type even when parent is main', () => {
+  it('親が main の場合でも特権グループタイプを作成しない', () => {
     const msg: InboundMessage = {
       id: 'msg6',
       chat_jid: threadJid,
@@ -179,7 +179,7 @@ describe('_autoRegisterThread (actual auto-registration path)', () => {
     expect(childType).toBe('thread');
   });
 
-  it('falls back to thread when parent thread_defaults.type is invalid at runtime', () => {
+  it('親の thread_defaults.type が実行時に無効な場合、thread にフォールバックする', () => {
     const corruptedParent: RegisteredGroup = {
       ...parent,
       // runtime 破損データ（DB/JSON改変）を再現するために型制約を意図的にバイパス

--- a/src/timezone.test.ts
+++ b/src/timezone.test.ts
@@ -5,8 +5,8 @@ import { formatLocalTime } from './timezone.js';
 // --- formatLocalTime ---
 
 describe('formatLocalTime', () => {
-  it('converts UTC to local time display', () => {
-    // 2026-02-04T18:30:00Z in America/New_York (EST, UTC-5) = 1:30 PM
+  it('UTC をローカル時刻表示に変換する', () => {
+    // 2026-02-04T18:30:00Z は America/New_York (EST, UTC-5) で午後 1:30
     const result = formatLocalTime(
       '2026-02-04T18:30:00.000Z',
       'America/New_York',
@@ -17,12 +17,12 @@ describe('formatLocalTime', () => {
     expect(result).toContain('2026');
   });
 
-  it('handles different timezones', () => {
-    // Same UTC time should produce different local times
+  it('異なるタイムゾーンを処理する', () => {
+    // 同じ UTC 時刻でも異なるローカル時刻を生成するべき
     const utc = '2026-06-15T12:00:00.000Z';
     const ny = formatLocalTime(utc, 'America/New_York');
     const tokyo = formatLocalTime(utc, 'Asia/Tokyo');
-    // NY is UTC-4 in summer (EDT), Tokyo is UTC+9
+    // 夏の NY は UTC-4 (EDT)、Tokyo は UTC+9
     expect(ny).toContain('8:00');
     expect(tokyo).toContain('9:00');
   });

--- a/src/timezone.test.ts
+++ b/src/timezone.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { formatLocalTime } from './timezone.js';
 
-// --- formatLocalTime ---
+// --- formatLocalTime のテスト ---
 
 describe('formatLocalTime', () => {
   it('UTC をローカル時刻表示に変換する', () => {


### PR DESCRIPTION
## 概要

src/ 以下の16ファイルについて、英語のコメント・JSDoc・テスト名を日本語に統一しました。

## 変更内容

- `src/channels/discord.ts` / `discord.test.ts`
- `src/channels/registry.test.ts`
- `src/container-runner.test.ts`
- `src/container-runtime.test.ts`
- `src/db.test.ts`
- `src/formatting.test.ts`
- `src/group-queue.test.ts`
- `src/ipc.ts` / `ipc-auth.test.ts`
- `src/remote-control.test.ts`
- `src/routing.test.ts`
- `src/sender-allowlist.test.ts`
- `src/task-scheduler.test.ts`
- `src/thread-auto-register.test.ts`
- `src/timezone.test.ts`

コードや変数名は一切変更していません。コメントのみの翻訳です。