### PR TITLE
fix: Atom フィード（YouTube等）の link 要素をオブジェクト形式で正しくパースする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,6 @@ groups/global/*
 # Skills system (local per-installation state)
 .nanoclaw/
 
-agents-sdk-docs
-
 docs/clone
-
+nanoclaw.yaml
 .ai/

--- a/src/rss-poller.ts
+++ b/src/rss-poller.ts
@@ -15,11 +15,27 @@ const xmlParser = new XMLParser({
 
 interface RssItem {
   title?: string;
-  link?: string;
+  link?:
+    | string
+    | { '@_href'?: string }
+    | Array<{ '@_href'?: string; '@_rel'?: string }>;
   guid?: string | { '#text'?: string; '@_isPermaLink'?: string };
   id?: string;
   pubDate?: string;
+  published?: string;
+  updated?: string;
   description?: string;
+}
+
+function extractLink(item: RssItem): string | undefined {
+  const l = item.link;
+  if (!l) return undefined;
+  if (typeof l === 'string') return l;
+  if (Array.isArray(l)) {
+    const alt = l.find((x) => x['@_rel'] === 'alternate') ?? l[0];
+    return alt?.['@_href'];
+  }
+  return l['@_href'];
 }
 
 function extractGuid(item: RssItem, feedUrl: string): string {
@@ -31,7 +47,8 @@ function extractGuid(item: RssItem, feedUrl: string): string {
     if (text) return text;
   }
   if (item.id) return item.id;
-  if (item.link) return item.link;
+  const link = extractLink(item);
+  if (link) return link;
   return `${feedUrl}#${item.title || 'untitled'}`;
 }
 
@@ -39,6 +56,10 @@ function parseTime(d?: string): number {
   if (!d) return Infinity;
   const t = new Date(d).getTime();
   return Number.isNaN(t) ? Infinity : t;
+}
+
+function itemDate(item: RssItem): string | undefined {
+  return item.pubDate ?? item.published ?? item.updated;
 }
 
 function sortByPubDate(
@@ -49,7 +70,7 @@ function sortByPubDate(
   // JS sort is stable (ES2019+). Items without pubDate sort to the end via Infinity.
   return [...items]
     .reverse()
-    .sort((a, b) => parseTime(a.item.pubDate) - parseTime(b.item.pubDate));
+    .sort((a, b) => parseTime(itemDate(a.item)) - parseTime(itemDate(b.item)));
 }
 
 async function fetchFeed(
@@ -146,7 +167,7 @@ export async function pollOnce(deps: RssPollerDeps): Promise<void> {
         const entry = sorted[i];
         const label = feed.name || feed.url;
         const title = entry.item.title?.trim() || '(no title)';
-        const link = entry.item.link?.trim() || '';
+        const link = extractLink(entry.item)?.trim() || '';
         const text = link
           ? `📰 **${label}**: ${title}\n${link}`
           : `📰 **${label}**: ${title}`;


### PR DESCRIPTION
## Summary

- `fast-xml-parser` が `<link rel="alternate" href="..."/>` を文字列でなくオブジェクト/配列として返すため、`link?.trim()` が `TypeError` になりポーラーが即クラッシュしていた
- `extractLink()` ヘルパーを追加し、`string` / `{ '@_href' }` / `Array<{ '@_href', '@_rel' }>` の各形式を統一処理
- `RssItem` に Atom フィード用の `published` / `updated` フィールドを追加し、日付ソートに使用
- `extractGuid()` でも `extractLink()` を利用するよう修正

## Test plan

- [ ] YouTube RSS フィード（Atom 形式）を購読し、新着動画が Discord チャンネルに投稿されることを確認
- [ ] 通常の RSS 2.0 フィード（`link` が文字列）でも引き続き動作することを確認
- [ ] `npm run build` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)