### PR TITLE
feat: add opencode-go provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,5 +64,8 @@ DISCORD_BOT_TOKEN=
 # 直接注入のため ALLOW_DIRECT_SECRET_INJECTION=true が必要
 # OAS_CODEX_AUTH_PATH=~/.codex/auth.json
 
+# Opencode GO API キー (プロキシ経由)
+# OPENCODE_GO_API_KEY=
+
 # 直接シークレット注入を許可 (Gemini/Codex で必須)
 # ALLOW_DIRECT_SECRET_INJECTION=true

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -156,6 +156,61 @@ describe('credential-proxy', () => {
     );
   });
 
+  it('opencode-go provider is included in proxy targets', async () => {
+    proxyPort = await startProxy({
+      go: {
+        name: 'go',
+        provider: 'opencode-go',
+        model: 'deepseek-v4-pro',
+        usesCredentialProxy: true,
+        allowDirectSecretInjection: false,
+        apiKey: 'sk-go-real-key',
+        upstreamBaseURL: `http://127.0.0.1:${upstreamPort}`,
+      },
+    });
+
+    const res = await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/__provider/go/v1/chat/completions',
+        headers: { 'content-type': 'application/json' },
+      },
+      '{}',
+    );
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('opencode-go route injects Authorization Bearer header and strips placeholder', async () => {
+    proxyPort = await startProxy({
+      go: {
+        name: 'go',
+        provider: 'opencode-go',
+        model: 'deepseek-v4-pro',
+        usesCredentialProxy: true,
+        allowDirectSecretInjection: false,
+        apiKey: 'sk-go-real-key',
+        upstreamBaseURL: `http://127.0.0.1:${upstreamPort}`,
+      },
+    });
+
+    await makeRequest(
+      proxyPort,
+      {
+        method: 'POST',
+        path: '/__provider/go/v1/chat/completions',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer placeholder',
+        },
+      },
+      '{}',
+    );
+
+    expect(lastUpstreamHeaders['authorization']).toBe('Bearer sk-go-real-key');
+  });
+
   it('returns 503 in disabled mode when only direct-injection providers exist', async () => {
     proxyPort = await startProxy({
       gemini: {

--- a/src/credential-proxy.test.ts
+++ b/src/credential-proxy.test.ts
@@ -12,9 +12,13 @@ const mockResolvedProviderConfig = vi.hoisted((): { value: any } => ({
   },
 }));
 
-vi.mock('./provider-config.js', () => ({
-  resolveProviderConfig: vi.fn(() => mockResolvedProviderConfig.value),
-}));
+vi.mock('./provider-config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./provider-config.js')>();
+  return {
+    ...actual,
+    resolveProviderConfig: vi.fn(() => mockResolvedProviderConfig.value),
+  };
+});
 
 vi.mock('./logger.js', () => ({
   logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -8,13 +8,13 @@ import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
 
 import { logger } from './logger.js';
-import { resolveProviderConfig } from './provider-config.js';
+import { isProxiedProvider, ProxiedProvider, resolveProviderConfig } from './provider-config.js';
 
 const PROVIDER_ROUTE_PREFIX = '/__provider/';
 
 interface ProxyTarget {
   name: string;
-  provider: 'anthropic' | 'openai' | 'opencode-go';
+  provider: ProxiedProvider;
   apiKey: string;
   upstreamBaseURL: string;
 }
@@ -45,7 +45,7 @@ function buildUpstreamPath(upstreamUrl: URL, requestUrl?: string): string {
 
 function injectAuthHeaders(
   headers: Record<string, string | number | string[] | undefined>,
-  provider: 'anthropic' | 'openai' | 'opencode-go',
+  provider: ProxiedProvider,
   apiKey: string,
 ): void {
   if (provider === 'anthropic') {
@@ -54,7 +54,7 @@ function injectAuthHeaders(
     return;
   }
 
-  // opencode-go は OpenAI 互換 API のため Bearer token 形式を使用する
+  // openai / opencode-go: OpenAI 互換 API のため Bearer token 形式を使用する
   delete headers['authorization'];
   headers['authorization'] = `Bearer ${apiKey}`;
 
@@ -69,11 +69,7 @@ function buildProxyTargets(): Record<string, ProxyTarget> {
   const targets: Record<string, ProxyTarget> = {};
 
   for (const [name, provider] of Object.entries(resolvedConfig.providers)) {
-    if (
-      provider.provider !== 'anthropic' &&
-      provider.provider !== 'openai' &&
-      provider.provider !== 'opencode-go'
-    ) {
+    if (!isProxiedProvider(provider.provider)) {
       continue;
     }
     targets[name] = {

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -54,6 +54,7 @@ function injectAuthHeaders(
     return;
   }
 
+  // opencode-go は OpenAI 互換 API のため Bearer token 形式を使用する
   delete headers['authorization'];
   headers['authorization'] = `Bearer ${apiKey}`;
 

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -8,7 +8,11 @@ import { request as httpsRequest } from 'https';
 import { request as httpRequest, RequestOptions } from 'http';
 
 import { logger } from './logger.js';
-import { isProxiedProvider, ProxiedProvider, resolveProviderConfig } from './provider-config.js';
+import {
+  isProxiedProvider,
+  ProxiedProvider,
+  resolveProviderConfig,
+} from './provider-config.js';
 
 const PROVIDER_ROUTE_PREFIX = '/__provider/';
 

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -14,7 +14,7 @@ const PROVIDER_ROUTE_PREFIX = '/__provider/';
 
 interface ProxyTarget {
   name: string;
-  provider: 'anthropic' | 'openai';
+  provider: 'anthropic' | 'openai' | 'opencode-go';
   apiKey: string;
   upstreamBaseURL: string;
 }
@@ -45,7 +45,7 @@ function buildUpstreamPath(upstreamUrl: URL, requestUrl?: string): string {
 
 function injectAuthHeaders(
   headers: Record<string, string | number | string[] | undefined>,
-  provider: 'anthropic' | 'openai',
+  provider: 'anthropic' | 'openai' | 'opencode-go',
   apiKey: string,
 ): void {
   if (provider === 'anthropic') {
@@ -68,7 +68,11 @@ function buildProxyTargets(): Record<string, ProxyTarget> {
   const targets: Record<string, ProxyTarget> = {};
 
   for (const [name, provider] of Object.entries(resolvedConfig.providers)) {
-    if (provider.provider !== 'anthropic' && provider.provider !== 'openai') {
+    if (
+      provider.provider !== 'anthropic' &&
+      provider.provider !== 'openai' &&
+      provider.provider !== 'opencode-go'
+    ) {
       continue;
     }
     targets[name] = {

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -203,7 +203,7 @@ describe('provider-config', () => {
       usesCredentialProxy: true,
       allowDirectSecretInjection: false,
       apiKey: 'go-key',
-      upstreamBaseURL: 'https://opencode.ai/zen/go/v1',
+      upstreamBaseURL: 'https://opencode.ai/zen/go',
     });
   });
 

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnv: Record<string, string> = {};
 const mockFiles = new Map<string, string>();
@@ -63,6 +63,10 @@ describe('provider-config', () => {
     resetMockEnv();
     mockFiles.clear();
     invalidateNanoclawYamlCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('falls back to legacy env detection when nanoclaw.yaml is absent', () => {
@@ -175,7 +179,131 @@ describe('provider-config', () => {
     expect(execution.fallbackProviders).toEqual(['claude', 'gemini']);
   });
 
+  it('resolves opencode-go provider from nanoclaw.yaml with default base URL', () => {
+    mockFiles.set(
+      `${process.cwd()}/nanoclaw.yaml`,
+      [
+        'providers:',
+        '  go:',
+        '    provider: opencode-go',
+        '    model: deepseek-v4-pro',
+      ].join('\n'),
+    );
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'go-key',
+    });
+
+    const config = resolveProviderConfig();
+
+    expect(config.source).toBe('yaml');
+    expect(config.defaultProvider).toBe('go');
+    expect(config.providers.go).toMatchObject({
+      provider: 'opencode-go',
+      model: 'deepseek-v4-pro',
+      usesCredentialProxy: true,
+      allowDirectSecretInjection: false,
+      apiKey: 'go-key',
+      upstreamBaseURL: 'https://opencode.ai/zen/go/v1',
+    });
+  });
+
+  it('respects OPENCODE_GO_BASE_URL override', () => {
+    mockFiles.set(
+      `${process.cwd()}/nanoclaw.yaml`,
+      [
+        'providers:',
+        '  go:',
+        '    provider: opencode-go',
+        '    model: kimi-k2.6',
+      ].join('\n'),
+    );
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'go-key',
+      OPENCODE_GO_BASE_URL: 'https://custom.opencode.example/v1',
+    });
+
+    const config = resolveProviderConfig();
+
+    expect(config.providers.go).toMatchObject({
+      upstreamBaseURL: 'https://custom.opencode.example/v1',
+    });
+  });
+
+  it('maps opencode-go to openai provider with proxy URL in container env', () => {
+    mockFiles.set(
+      `${process.cwd()}/nanoclaw.yaml`,
+      [
+        'providers:',
+        '  go:',
+        '    provider: opencode-go',
+        '    model: deepseek-v4-pro',
+      ].join('\n'),
+    );
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'go-key',
+    });
+
+    const config = resolveProviderConfig();
+    const env = buildContainerProviderEnv(
+      config,
+      undefined,
+      'host.docker.internal',
+      3001,
+    );
+    const parsed = JSON.parse(env.NANOCLAW_PROVIDER_CONFIG_JSON);
+
+    expect(parsed.defaultProvider).toBe('go');
+    expect(parsed.providers.go).toEqual({
+      provider: 'openai',
+      model: 'deepseek-v4-pro',
+      apiKey: 'placeholder-go',
+      baseURL: 'http://host.docker.internal:3001/__provider/go',
+    });
+  });
+
+  it('uses OPENCODE_GO_MODEL env var as model default', () => {
+    mockFiles.set(
+      `${process.cwd()}/nanoclaw.yaml`,
+      [
+        'providers:',
+        '  go:',
+        '    provider: opencode-go',
+        '    model: kimi-k2.6',
+      ].join('\n'),
+    );
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'go-key',
+    });
+
+    const config = resolveProviderConfig();
+
+    expect(config.providers.go.model).toBe('kimi-k2.6');
+  });
+
+  it('does not require ALLOW_DIRECT_SECRET_INJECTION for opencode-go', () => {
+    mockFiles.set(
+      `${process.cwd()}/nanoclaw.yaml`,
+      [
+        'providers:',
+        '  go:',
+        '    provider: opencode-go',
+        '    model: deepseek-v4-pro',
+      ].join('\n'),
+    );
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'go-key',
+      // ALLOW_DIRECT_SECRET_INJECTION は設定しない
+    });
+
+    expect(() => resolveProviderConfig()).not.toThrow();
+  });
+
   it('builds container env with proxy URLs and direct secrets', () => {
+    // process.env の実キーが mock を上書きしないよう stub する
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+    vi.stubEnv('GEMINI_API_KEY', 'gem-key');
+    vi.stubEnv('ALLOW_DIRECT_SECRET_INJECTION', 'true');
     mockFiles.set(
       `${process.cwd()}/nanoclaw.yaml`,
       [

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -90,6 +90,26 @@ describe('provider-config', () => {
     });
   });
 
+  it('falls back to legacy env detection with opencode-go when nanoclaw.yaml is absent', () => {
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'sk-go-key',
+    });
+
+    const config = resolveProviderConfig();
+
+    expect(config.source).toBe('env');
+    expect(config.defaultProvider).toBe('default');
+    expect(config.fallbackProviders).toEqual([]);
+    expect(config.providers.default).toMatchObject({
+      provider: 'opencode-go',
+      model: 'deepseek-v4-pro',
+      usesCredentialProxy: true,
+      allowDirectSecretInjection: false,
+      apiKey: 'sk-go-key',
+      upstreamBaseURL: 'https://opencode.ai/zen/go',
+    });
+  });
+
   it('loads named providers from nanoclaw.yaml', () => {
     mockFiles.set(
       `${process.cwd()}/nanoclaw.yaml`,
@@ -261,7 +281,7 @@ describe('provider-config', () => {
     });
   });
 
-  it('uses OPENCODE_GO_MODEL env var as model default', () => {
+  it('uses model configured in nanoclaw.yaml', () => {
     mockFiles.set(
       `${process.cwd()}/nanoclaw.yaml`,
       [
@@ -278,6 +298,19 @@ describe('provider-config', () => {
     const config = resolveProviderConfig();
 
     expect(config.providers.go.model).toBe('kimi-k2.6');
+  });
+
+  it('uses OPENCODE_GO_MODEL env var as model when resolving via legacy env (no yaml)', () => {
+    // YAML なしの場合、OPENCODE_GO_MODEL が model の優先ソースになる
+    Object.assign(mockEnv, {
+      OPENCODE_GO_API_KEY: 'go-key',
+      OPENCODE_GO_MODEL: 'kimi-k2.6',
+    });
+
+    const config = resolveProviderConfig();
+
+    expect(config.source).toBe('env');
+    expect(config.providers.default.model).toBe('kimi-k2.6');
   });
 
   it('does not require ALLOW_DIRECT_SECRET_INJECTION for opencode-go', () => {

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -67,6 +67,7 @@ describe('provider-config', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    resetMockEnv();
   });
 
   it('falls back to legacy env detection when nanoclaw.yaml is absent', () => {

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -95,7 +95,7 @@ describe('provider-config', () => {
     expect(config.fallbackProviders).toEqual([]);
     expect(config.providers.default).toMatchObject({
       provider: 'opencode-go',
-      model: 'deepseek-v4-pro',
+      model: 'kimi-k2.6',
       usesCredentialProxy: true,
       allowDirectSecretInjection: false,
       apiKey: 'sk-go-key',

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,11 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockEnv: Record<string, string> = {};
-const mockFiles = new Map<string, string>();
+import { ENV_KEYS } from './provider-config.js';
 
-vi.mock('./env.js', () => ({
-  readEnvFile: vi.fn(() => ({ ...mockEnv })),
-}));
+const mockFiles = new Map<string, string>();
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
@@ -52,30 +49,27 @@ import {
   resolveProviderExecutionConfig,
 } from './provider-config.js';
 
-function resetMockEnv(): void {
-  for (const key of Object.keys(mockEnv)) {
-    delete mockEnv[key];
+function resetEnv(): void {
+  for (const key of ENV_KEYS) {
+    vi.stubEnv(key, '');
   }
 }
 
 describe('provider-config', () => {
   beforeEach(() => {
-    resetMockEnv();
+    resetEnv();
     mockFiles.clear();
     invalidateNanoclawYamlCache();
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    resetMockEnv();
   });
 
   it('falls back to legacy env detection when nanoclaw.yaml is absent', () => {
-    Object.assign(mockEnv, {
-      OPENAI_API_KEY: 'sk-openai',
-      OPENAI_BASE_URL: 'https://example.openai.local',
-      OPENAI_MODEL: 'gpt-4.1',
-    });
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+    vi.stubEnv('OPENAI_BASE_URL', 'https://example.openai.local');
+    vi.stubEnv('OPENAI_MODEL', 'gpt-4.1');
 
     const config = resolveProviderConfig();
 
@@ -92,14 +86,7 @@ describe('provider-config', () => {
   });
 
   it('falls back to legacy env detection with opencode-go when nanoclaw.yaml is absent', () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', '');
-    vi.stubEnv('OPENAI_API_KEY', '');
-    vi.stubEnv('GEMINI_API_KEY', '');
-    vi.stubEnv('OAS_CODEX_AUTH_PATH', '');
     vi.stubEnv('OPENCODE_GO_API_KEY', 'sk-go-key');
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'sk-go-key',
-    });
 
     const config = resolveProviderConfig();
 
@@ -132,10 +119,8 @@ describe('provider-config', () => {
         '  - fast',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      ANTHROPIC_API_KEY: 'sk-ant',
-      OPENAI_API_KEY: 'sk-openai',
-    });
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
 
     const config = resolveProviderConfig();
 
@@ -162,9 +147,7 @@ describe('provider-config', () => {
         '    model: gemini-2.5-flash',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      GEMINI_API_KEY: 'gem-key',
-    });
+    vi.stubEnv('GEMINI_API_KEY', 'gem-key');
 
     expect(() => resolveProviderConfig()).toThrow(
       'ALLOW_DIRECT_SECRET_INJECTION=true is not set',
@@ -191,12 +174,10 @@ describe('provider-config', () => {
         '  - gemini',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      ANTHROPIC_API_KEY: 'sk-ant',
-      OPENAI_API_KEY: 'sk-openai',
-      GEMINI_API_KEY: 'gem-key',
-      ALLOW_DIRECT_SECRET_INJECTION: 'true',
-    });
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+    vi.stubEnv('GEMINI_API_KEY', 'gem-key');
+    vi.stubEnv('ALLOW_DIRECT_SECRET_INJECTION', 'true');
 
     const config = resolveProviderConfig();
     const execution = resolveProviderExecutionConfig(config, 'fast');
@@ -217,9 +198,6 @@ describe('provider-config', () => {
         '    model: deepseek-v4-pro',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'go-key',
-    });
 
     const config = resolveProviderConfig();
 
@@ -247,10 +225,6 @@ describe('provider-config', () => {
         '    model: kimi-k2.6',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'go-key',
-      OPENCODE_GO_BASE_URL: 'https://custom.opencode.example/v1',
-    });
 
     const config = resolveProviderConfig();
 
@@ -269,9 +243,7 @@ describe('provider-config', () => {
         '    model: deepseek-v4-pro',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'go-key',
-    });
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
 
     const config = resolveProviderConfig();
     const env = buildContainerProviderEnv(
@@ -301,9 +273,7 @@ describe('provider-config', () => {
         '    model: kimi-k2.6',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'go-key',
-    });
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
 
     const config = resolveProviderConfig();
 
@@ -312,16 +282,8 @@ describe('provider-config', () => {
 
   it('uses OPENCODE_GO_MODEL env var as model when resolving via legacy env (no yaml)', () => {
     // YAML なしの場合、OPENCODE_GO_MODEL が model の優先ソースになる
-    vi.stubEnv('ANTHROPIC_API_KEY', '');
-    vi.stubEnv('OPENAI_API_KEY', '');
-    vi.stubEnv('GEMINI_API_KEY', '');
-    vi.stubEnv('OAS_CODEX_AUTH_PATH', '');
     vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
     vi.stubEnv('OPENCODE_GO_MODEL', 'kimi-k2.6');
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'go-key',
-      OPENCODE_GO_MODEL: 'kimi-k2.6',
-    });
 
     const config = resolveProviderConfig();
 
@@ -339,10 +301,8 @@ describe('provider-config', () => {
         '    model: deepseek-v4-pro',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      OPENCODE_GO_API_KEY: 'go-key',
-      // ALLOW_DIRECT_SECRET_INJECTION は設定しない
-    });
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
+    // ALLOW_DIRECT_SECRET_INJECTION は設定しない
 
     expect(() => resolveProviderConfig()).not.toThrow();
   });
@@ -372,12 +332,6 @@ describe('provider-config', () => {
         '  - gemini',
       ].join('\n'),
     );
-    Object.assign(mockEnv, {
-      ANTHROPIC_API_KEY: 'sk-ant',
-      OPENAI_API_KEY: 'sk-openai',
-      GEMINI_API_KEY: 'gem-key',
-      ALLOW_DIRECT_SECRET_INJECTION: 'true',
-    });
 
     const config = resolveProviderConfig();
     const env = buildContainerProviderEnv(

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -91,6 +91,11 @@ describe('provider-config', () => {
   });
 
   it('falls back to legacy env detection with opencode-go when nanoclaw.yaml is absent', () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('GEMINI_API_KEY', '');
+    vi.stubEnv('OAS_CODEX_AUTH_PATH', '');
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'sk-go-key');
     Object.assign(mockEnv, {
       OPENCODE_GO_API_KEY: 'sk-go-key',
     });
@@ -200,6 +205,8 @@ describe('provider-config', () => {
   });
 
   it('resolves opencode-go provider from nanoclaw.yaml with default base URL', () => {
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
+    vi.stubEnv('OPENCODE_GO_BASE_URL', '');
     mockFiles.set(
       `${process.cwd()}/nanoclaw.yaml`,
       [
@@ -228,6 +235,8 @@ describe('provider-config', () => {
   });
 
   it('respects OPENCODE_GO_BASE_URL override', () => {
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
+    vi.stubEnv('OPENCODE_GO_BASE_URL', 'https://custom.opencode.example/v1');
     mockFiles.set(
       `${process.cwd()}/nanoclaw.yaml`,
       [
@@ -302,6 +311,12 @@ describe('provider-config', () => {
 
   it('uses OPENCODE_GO_MODEL env var as model when resolving via legacy env (no yaml)', () => {
     // YAML なしの場合、OPENCODE_GO_MODEL が model の優先ソースになる
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('GEMINI_API_KEY', '');
+    vi.stubEnv('OAS_CODEX_AUTH_PATH', '');
+    vi.stubEnv('OPENCODE_GO_API_KEY', 'go-key');
+    vi.stubEnv('OPENCODE_GO_MODEL', 'kimi-k2.6');
     Object.assign(mockEnv, {
       OPENCODE_GO_API_KEY: 'go-key',
       OPENCODE_GO_MODEL: 'kimi-k2.6',

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -99,7 +99,7 @@ describe('provider-config', () => {
       usesCredentialProxy: true,
       allowDirectSecretInjection: false,
       apiKey: 'sk-go-key',
-      upstreamBaseURL: 'https://opencode.ai/zen/go',
+      upstreamBaseURL: 'https://opencode.ai/zen/go/v1',
     });
   });
 
@@ -209,7 +209,7 @@ describe('provider-config', () => {
       usesCredentialProxy: true,
       allowDirectSecretInjection: false,
       apiKey: 'go-key',
-      upstreamBaseURL: 'https://opencode.ai/zen/go',
+      upstreamBaseURL: 'https://opencode.ai/zen/go/v1',
     });
   });
 

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -78,7 +78,7 @@ const DEFAULT_UPSTREAM_BASE_URL: Record<
 > = {
   anthropic: 'https://api.anthropic.com',
   openai: 'https://api.openai.com',
-  'opencode-go': 'https://opencode.ai/zen/go/v1',
+  'opencode-go': 'https://opencode.ai/zen/go',
 };
 
 const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProvider, string> = {

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -6,7 +6,12 @@ import YAML from 'yaml';
 
 import { readEnvFile } from './env.js';
 
-export type LlmProvider = 'anthropic' | 'openai' | 'google' | 'codex' | 'opencode-go';
+export type LlmProvider =
+  | 'anthropic'
+  | 'openai'
+  | 'google'
+  | 'codex'
+  | 'opencode-go';
 
 export interface ProviderConfig {
   name: string;
@@ -67,7 +72,10 @@ const ENV_KEYS = [
   'ALLOW_DIRECT_SECRET_INJECTION',
 ] as const;
 
-const DEFAULT_UPSTREAM_BASE_URL: Record<'anthropic' | 'openai' | 'opencode-go', string> = {
+const DEFAULT_UPSTREAM_BASE_URL: Record<
+  'anthropic' | 'openai' | 'opencode-go',
+  string
+> = {
   anthropic: 'https://api.anthropic.com',
   openai: 'https://api.openai.com',
   'opencode-go': 'https://opencode.ai/zen/go/v1',
@@ -508,7 +516,8 @@ export function buildContainerProviderEnv(
       config.provider === 'opencode-go'
     ) {
       providers[name] = {
-        provider: config.provider === 'opencode-go' ? 'openai' : config.provider,
+        provider:
+          config.provider === 'opencode-go' ? 'openai' : config.provider,
         model: config.model,
         apiKey: `placeholder-${name}`,
         baseURL: `${proxyBaseUrl}/__provider/${encodeURIComponent(name)}`,

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -102,6 +102,12 @@ function requiredValue(
   );
 }
 
+export type ProxiedProvider = 'anthropic' | 'openai' | 'opencode-go';
+
+export function isProxiedProvider(p: LlmProvider): p is ProxiedProvider {
+  return p === 'anthropic' || p === 'openai' || p === 'opencode-go';
+}
+
 function isDirectSecretInjectionEnabled(value: string | undefined): boolean {
   return value === 'true';
 }
@@ -508,12 +514,10 @@ export function buildContainerProviderEnv(
   const providers: Record<string, ContainerProviderConfig> = {};
 
   for (const [name, config] of Object.entries(execution.providers)) {
-    if (
-      config.provider === 'anthropic' ||
-      config.provider === 'openai' ||
-      config.provider === 'opencode-go'
-    ) {
+    if (isProxiedProvider(config.provider)) {
       providers[name] = {
+        // コンテナ内の既存 OpenAI クライアントと互換性を保つため、
+        // opencode-go は OpenAI 互換 API として openai に変換する
         provider:
           config.provider === 'opencode-go' ? 'openai' : config.provider,
         model: config.model,

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -88,7 +88,7 @@ const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProvider, string> = {
   openai: 'gpt-4.1-mini',
   google: 'gemini-2.5-flash',
   codex: 'gpt-5.4',
-  'opencode-go': 'deepseek-v4-pro',
+  'opencode-go': 'kimi-k2.6',
 };
 
 function requiredValue(

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -72,6 +72,8 @@ const ENV_KEYS = [
   'ALLOW_DIRECT_SECRET_INJECTION',
 ] as const;
 
+// credential proxy を経由するプロバイダーのみ登録する。
+// google/codex は独自の認証フロー（OAuth / SDK）を持つため proxy を使わず、このマップには含まない。
 const DEFAULT_UPSTREAM_BASE_URL: Record<
   'anthropic' | 'openai' | 'opencode-go',
   string

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -6,7 +6,7 @@ import YAML from 'yaml';
 
 import { readEnvFile } from './env.js';
 
-export type LlmProvider = 'anthropic' | 'openai' | 'google' | 'codex';
+export type LlmProvider = 'anthropic' | 'openai' | 'google' | 'codex' | 'opencode-go';
 
 export interface ProviderConfig {
   name: string;
@@ -46,6 +46,7 @@ const PROVIDER_PRIORITY: LlmProvider[] = [
   'openai',
   'google',
   'codex',
+  'opencode-go',
 ];
 
 const ENV_KEYS = [
@@ -60,12 +61,16 @@ const ENV_KEYS = [
   'CODEX_MODEL',
   'OAS_CODEX_OAUTH_JSON',
   'OAS_CODEX_AUTH_PATH',
+  'OPENCODE_GO_API_KEY',
+  'OPENCODE_GO_BASE_URL',
+  'OPENCODE_GO_MODEL',
   'ALLOW_DIRECT_SECRET_INJECTION',
 ] as const;
 
-const DEFAULT_UPSTREAM_BASE_URL: Record<'anthropic' | 'openai', string> = {
+const DEFAULT_UPSTREAM_BASE_URL: Record<'anthropic' | 'openai' | 'opencode-go', string> = {
   anthropic: 'https://api.anthropic.com',
   openai: 'https://api.openai.com',
+  'opencode-go': 'https://opencode.ai/zen/go/v1',
 };
 
 const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProvider, string> = {
@@ -73,6 +78,7 @@ const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProvider, string> = {
   openai: 'gpt-4.1-mini',
   google: 'gemini-2.5-flash',
   codex: 'gpt-5.4',
+  'opencode-go': 'deepseek-v4-pro',
 };
 
 function requiredValue(
@@ -188,6 +194,27 @@ function resolveProviderFromEnv(
       usesCredentialProxy: false,
       allowDirectSecretInjection,
       apiKey: requiredValue(env.GEMINI_API_KEY, 'GEMINI_API_KEY', provider),
+    };
+  }
+
+  if (provider === 'opencode-go') {
+    if (!env.OPENCODE_GO_API_KEY) return undefined;
+    return {
+      name,
+      provider,
+      model:
+        modelOverride ||
+        env.OPENCODE_GO_MODEL ||
+        DEFAULT_MODEL_BY_PROVIDER['opencode-go'],
+      usesCredentialProxy: true,
+      allowDirectSecretInjection: false,
+      apiKey: requiredValue(
+        env.OPENCODE_GO_API_KEY,
+        'OPENCODE_GO_API_KEY',
+        provider,
+      ),
+      upstreamBaseURL:
+        env.OPENCODE_GO_BASE_URL || DEFAULT_UPSTREAM_BASE_URL['opencode-go'],
     };
   }
 
@@ -314,7 +341,8 @@ function normalizeYamlProvider(provider: string): LlmProvider {
   if (
     provider === 'anthropic' ||
     provider === 'openai' ||
-    provider === 'codex'
+    provider === 'codex' ||
+    provider === 'opencode-go'
   ) {
     return provider;
   }
@@ -416,7 +444,7 @@ function resolveLegacyProviderConfig(
 
   throw new Error(
     '[provider-config] No supported provider credentials found.\n' +
-      'Set one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OAS_CODEX_AUTH_PATH\n' +
+      'Set one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OAS_CODEX_AUTH_PATH, OPENCODE_GO_API_KEY\n' +
       '(Or have ~/.codex/auth.json from `codex login`)\n' +
       '\n' +
       'NOTE: OAuth-based authentication (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN) is not supported.\n' +
@@ -474,9 +502,13 @@ export function buildContainerProviderEnv(
   const providers: Record<string, ContainerProviderConfig> = {};
 
   for (const [name, config] of Object.entries(execution.providers)) {
-    if (config.provider === 'anthropic' || config.provider === 'openai') {
+    if (
+      config.provider === 'anthropic' ||
+      config.provider === 'openai' ||
+      config.provider === 'opencode-go'
+    ) {
       providers[name] = {
-        provider: config.provider,
+        provider: config.provider === 'opencode-go' ? 'openai' : config.provider,
         model: config.model,
         apiKey: `placeholder-${name}`,
         baseURL: `${proxyBaseUrl}/__provider/${encodeURIComponent(name)}`,

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -54,7 +54,7 @@ const PROVIDER_PRIORITY: LlmProvider[] = [
   'opencode-go',
 ];
 
-const ENV_KEYS = [
+export const ENV_KEYS = [
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_MODEL',

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -218,11 +218,7 @@ function resolveProviderFromEnv(
         DEFAULT_MODEL_BY_PROVIDER['opencode-go'],
       usesCredentialProxy: true,
       allowDirectSecretInjection: false,
-      apiKey: requiredValue(
-        env.OPENCODE_GO_API_KEY,
-        'OPENCODE_GO_API_KEY',
-        provider,
-      ),
+      apiKey: env.OPENCODE_GO_API_KEY,
       upstreamBaseURL:
         env.OPENCODE_GO_BASE_URL || DEFAULT_UPSTREAM_BASE_URL['opencode-go'],
     };

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -80,7 +80,7 @@ const DEFAULT_UPSTREAM_BASE_URL: Record<
 > = {
   anthropic: 'https://api.anthropic.com',
   openai: 'https://api.openai.com',
-  'opencode-go': 'https://opencode.ai/zen/go',
+  'opencode-go': 'https://opencode.ai/zen/go/v1',
 };
 
 const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProvider, string> = {

--- a/src/rss-poller.ts
+++ b/src/rss-poller.ts
@@ -32,7 +32,8 @@ function extractLink(item: RssItem): string {
   if (typeof l === 'string') return l.trim();
   if (Array.isArray(l)) {
     // RFC 4287: rel 省略は rel="alternate" と同義
-    const alt = l.find((x) => !x['@_rel'] || x['@_rel'] === 'alternate') ?? l[0];
+    const alt =
+      l.find((x) => !x['@_rel'] || x['@_rel'] === 'alternate') ?? l[0];
     return alt?.['@_href']?.trim() ?? '';
   }
   return l['@_href']?.trim() ?? '';


### PR DESCRIPTION
## Summary

Add support for the `opencode-go` LLM provider.

## Changes

- Extend `LlmProvider` type and related configs to accept `opencode-go`
- Add default base URL (`https://opencode.ai/zen/go`) and model (`deepseek-v4-pro`)
- Update credential-proxy to route `opencode-go` requests (maps to OpenAI-compatible format in containers)
- Add comprehensive tests for YAML resolution, env var overrides, and container env building
- Fix test isolation by adding `afterEach(() => vi.unstubAllEnvs())`

## Provider Mapping

`opencode-go` is handled similarly to `anthropic`/`openai`:
- Uses the credential proxy for API key security
- Inside containers, it is mapped to `provider: openai` with the proxy baseURL so existing OpenAI-compatible clients work out of the box.